### PR TITLE
PG_FREE_IF_COPY in hash op

### DIFF
--- a/src/hierarchy.c
+++ b/src/hierarchy.c
@@ -57,6 +57,7 @@ h3_to_parent(PG_FUNCTION_ARGS)
 	*parent = h3ToParent(*origin, parentRes);
 	ASSERT_EXTERNAL(*parent, "Could not generate parent");
 
+	PG_FREE_IF_COPY(origin, 0);
 	PG_RETURN_H3_INDEX_P(parent);
 }
 
@@ -106,6 +107,7 @@ h3_to_children(PG_FUNCTION_ARGS)
 		children = palloc(size);
 		h3ToChildren(*origin, resolution, children);
 		ASSERT_EXTERNAL(*children, "Could not generate children");
+		PG_FREE_IF_COPY(origin, 0);
 
 		funcctx->user_fctx = children;
 		funcctx->max_calls = maxSize;
@@ -146,6 +148,7 @@ h3_to_center_child(PG_FUNCTION_ARGS)
 	*child = h3ToCenterChild(*origin, childRes);
 	ASSERT_EXTERNAL(*child, "Could not generate center child");
 
+	PG_FREE_IF_COPY(origin, 0);
 	PG_RETURN_H3_INDEX_P(child);
 }
 

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -42,6 +42,7 @@ h3_geo_to_h3(PG_FUNCTION_ARGS)
 	*idx = geoToH3(&location, resolution);
 	ASSERT_EXTERNAL(*idx, "Indexing failed at specified resolution.");
 
+	PG_FREE_IF_COPY(geo, 0);
 	PG_RETURN_H3_INDEX_P(idx);
 }
 
@@ -59,6 +60,7 @@ h3_to_geo(PG_FUNCTION_ARGS)
 	geo->x = radsToDegs(center.lon);
 	geo->y = radsToDegs(center.lat);
 
+	PG_FREE_IF_COPY(idx, 0);
 	PG_RETURN_POINT_P(geo);
 }
 
@@ -108,5 +110,6 @@ h3_to_geo_boundary(PG_FUNCTION_ARGS)
 		polygon->p[v].y = radsToDegs(lat);
 	}
 
+	PG_FREE_IF_COPY(idx, 0);
 	PG_RETURN_POLYGON_P(polygon);
 }

--- a/src/inspection.c
+++ b/src/inspection.c
@@ -36,7 +36,7 @@ h3_get_resolution(PG_FUNCTION_ARGS)
 {
 	H3Index    *hex = PG_GETARG_H3_INDEX_P(0);
 	int			resolution = h3GetResolution(*hex);
-
+	PG_FREE_IF_COPY(hex, 0);
 	PG_RETURN_INT32(resolution);
 }
 
@@ -46,7 +46,7 @@ h3_get_base_cell(PG_FUNCTION_ARGS)
 {
 	H3Index    *hex = PG_GETARG_H3_INDEX_P(0);
 	int			base_cell_number = h3GetBaseCell(*hex);
-
+	PG_FREE_IF_COPY(hex, 0);
 	PG_RETURN_INT32(base_cell_number);
 }
 
@@ -56,7 +56,7 @@ h3_is_valid(PG_FUNCTION_ARGS)
 {
 	H3Index    *hex = PG_GETARG_H3_INDEX_P(0);
 	bool		isValid = h3IsValid(*hex);
-
+	PG_FREE_IF_COPY(hex, 0);
 	PG_RETURN_BOOL(isValid);
 }
 
@@ -66,7 +66,7 @@ h3_is_res_class_iii(PG_FUNCTION_ARGS)
 {
 	H3Index    *hex = PG_GETARG_H3_INDEX_P(0);
 	bool		isResClassIII = h3IsResClassIII(*hex);
-
+	PG_FREE_IF_COPY(hex, 0);
 	PG_RETURN_BOOL(isResClassIII);
 }
 
@@ -76,7 +76,7 @@ h3_is_pentagon(PG_FUNCTION_ARGS)
 {
 	H3Index    *hex = PG_GETARG_H3_INDEX_P(0);
 	bool		isPentagon = h3IsPentagon(*hex);
-
+	PG_FREE_IF_COPY(hex, 0);
 	PG_RETURN_BOOL(isPentagon);
 }
 
@@ -114,6 +114,6 @@ h3_get_faces(PG_FUNCTION_ARGS)
 	/* build the array */
 	get_typlenbyvalalign(elmtype, &elmlen, &elmbyval, &elmalign);
 	result = construct_array(elements, nelems, elmtype, elmlen, elmbyval, elmalign);
-
+	PG_FREE_IF_COPY(hex, 0);
 	PG_RETURN_ARRAYTYPE_P(result);
 }

--- a/src/opclass_btree.c
+++ b/src/opclass_btree.c
@@ -28,10 +28,13 @@ h3index_cmp(PG_FUNCTION_ARGS)
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 
-	if (*a > *b)
-		PG_RETURN_INT32(1);
-	else if (*a == *b)
-		PG_RETURN_INT32(0);
-	else
-		PG_RETURN_INT32(-1);
+	uint32_t ret = 0;
+	if (*a < *b)
+		ret = 1;
+	else if (*a > *b)
+		ret = -1;
+
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 1);
+	PG_RETURN_INT32(ret);
 }

--- a/src/opclass_hash.c
+++ b/src/opclass_hash.c
@@ -28,6 +28,6 @@ h3index_hash(PG_FUNCTION_ARGS)
 {
 	H3Index    *index = PG_GETARG_H3_INDEX_P(0);
 	uint32		hash = hash_any((unsigned char *) index, sizeof(H3Index));
-
+	PG_FREE_IF_COPY(index, 0);
 	PG_RETURN_INT32(hash);
 }

--- a/src/traversal.c
+++ b/src/traversal.c
@@ -60,6 +60,7 @@ h3_k_ring(PG_FUNCTION_ARGS)
 		H3Index    *indices = palloc(maxSize * sizeof(H3Index));
 
 		kRing(*origin, k, indices);
+		PG_FREE_IF_COPY(origin, 0);
 
 		funcctx->user_fctx = indices;
 		funcctx->max_calls = maxSize;
@@ -105,6 +106,7 @@ h3_k_ring_distances(PG_FUNCTION_ARGS)
 		user_fctx->distances = palloc(maxSize * sizeof(int));
 
 		kRingDistances(*origin, k, user_fctx->indices, user_fctx->distances);
+		PG_FREE_IF_COPY(origin, 0);
 
 		ENSURE_TYPEFUNC_COMPOSITE(get_call_result_type(fcinfo, NULL, &tuple_desc));
 
@@ -152,6 +154,7 @@ h3_hex_ring(PG_FUNCTION_ARGS)
 		indices = palloc(maxSize * sizeof(H3Index));
 
 		result = hexRing(*origin, k, indices);
+		PG_FREE_IF_COPY(origin, 0);
 		ASSERT_EXTERNAL(result == 0, "Pentagonal distortion encountered, this method is undefined when it encounters pentagons");
 
 		funcctx->user_fctx = indices;
@@ -179,7 +182,8 @@ h3_distance(PG_FUNCTION_ARGS)
 	int			distance;
 
 	distance = h3Distance(*originIndex, *h3Index);
-
+	PG_FREE_IF_COPY(originIndex, 0);
+	PG_FREE_IF_COPY(h3Index, 1);
 	PG_RETURN_INT32(distance);
 }
 
@@ -206,6 +210,8 @@ h3_line(PG_FUNCTION_ARGS)
 		H3Index    *indices = palloc(size * sizeof(H3Index));
 
 		int			result = h3Line(*start, *end, indices);
+		PG_FREE_IF_COPY(start, 0);
+		PG_FREE_IF_COPY(end, 1);
 
 		ASSERT_EXTERNAL(result == 0, "Failed to generate line");
 
@@ -236,7 +242,8 @@ h3_experimental_h3_to_local_ij(PG_FUNCTION_ARGS)
 
 	point->x = coord.i;
 	point->y = coord.j;
-
+	PG_FREE_IF_COPY(origin, 0);
+	PG_FREE_IF_COPY(index, 1);
 	PG_RETURN_POINT_P(point);
 }
 
@@ -260,6 +267,7 @@ h3_experimental_local_ij_to_h3(PG_FUNCTION_ARGS)
 	coord.j = point->y;
 
 	experimentalLocalIjToH3(*origin, &coord, index);
-
+	PG_FREE_IF_COPY(origin, 0);
+	PG_FREE_IF_COPY(point, 1);
 	PG_RETURN_H3_INDEX_P(index);
 }

--- a/src/type.c
+++ b/src/type.c
@@ -81,7 +81,7 @@ h3index_out(PG_FUNCTION_ARGS)
 	char	   *str = palloc(17 * sizeof(char));
 
 	h3ToString(*hex, str, 17);
-
+	PG_FREE_IF_COPY(hex, 0);
 	PG_RETURN_CSTRING(str);
 }
 
@@ -110,8 +110,10 @@ h3index_eq(PG_FUNCTION_ARGS)
 {
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
-
-	PG_RETURN_BOOL(*a == *b);
+	bool ret = *a == *b;
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 0);
+	PG_RETURN_BOOL(ret);
 }
 
 Datum
@@ -119,8 +121,10 @@ h3index_ne(PG_FUNCTION_ARGS)
 {
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
-
-	PG_RETURN_BOOL(*a != *b);
+	bool ret = *a != *b;
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 0);
+	PG_RETURN_BOOL(ret);
 }
 
 Datum
@@ -128,8 +132,10 @@ h3index_lt(PG_FUNCTION_ARGS)
 {
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
-
-	PG_RETURN_BOOL(*a < *b);
+	bool ret = *a < *b;
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 0);
+	PG_RETURN_BOOL(ret);
 }
 
 Datum
@@ -137,8 +143,10 @@ h3index_le(PG_FUNCTION_ARGS)
 {
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
-
-	PG_RETURN_BOOL(*a <= *b);
+	bool ret = *a <= *b;
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 0);
+	PG_RETURN_BOOL(ret);
 }
 
 Datum
@@ -146,8 +154,10 @@ h3index_gt(PG_FUNCTION_ARGS)
 {
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
-
-	PG_RETURN_BOOL(*a > *b);
+	bool ret = *a > *b;
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 0);
+	PG_RETURN_BOOL(ret);
 }
 
 Datum
@@ -155,8 +165,10 @@ h3index_ge(PG_FUNCTION_ARGS)
 {
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
-
-	PG_RETURN_BOOL(*a >= *b);
+	bool ret = *a >= *b;
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 0);
+	PG_RETURN_BOOL(ret);
 }
 
 /* r-tree operators */
@@ -165,8 +177,10 @@ h3index_overlaps(PG_FUNCTION_ARGS)
 {
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
-
-	PG_RETURN_BOOL(containment(a, b) != 0);
+	bool ret = containment(a, b) != 0;
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 0);
+	PG_RETURN_BOOL(ret);
 }
 
 Datum
@@ -174,8 +188,10 @@ h3index_contains(PG_FUNCTION_ARGS)
 {
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
-
-	PG_RETURN_BOOL(containment(a, b) > 0);
+	bool ret = containment(a, b) > 0;
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 0);
+	PG_RETURN_BOOL(ret);
 }
 
 Datum
@@ -183,6 +199,8 @@ h3index_contained_by(PG_FUNCTION_ARGS)
 {
 	H3Index    *a = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
-
-	PG_RETURN_BOOL(containment(a, b) < 0);
+	bool ret = containment(a, b) < 0;
+	PG_FREE_IF_COPY(a, 0);
+	PG_FREE_IF_COPY(b, 0);
+	PG_RETURN_BOOL(ret);
 }

--- a/src/type.c
+++ b/src/type.c
@@ -112,7 +112,7 @@ h3index_eq(PG_FUNCTION_ARGS)
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 	bool ret = *a == *b;
 	PG_FREE_IF_COPY(a, 0);
-	PG_FREE_IF_COPY(b, 0);
+	PG_FREE_IF_COPY(b, 1);
 	PG_RETURN_BOOL(ret);
 }
 
@@ -123,7 +123,7 @@ h3index_ne(PG_FUNCTION_ARGS)
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 	bool ret = *a != *b;
 	PG_FREE_IF_COPY(a, 0);
-	PG_FREE_IF_COPY(b, 0);
+	PG_FREE_IF_COPY(b, 1);
 	PG_RETURN_BOOL(ret);
 }
 
@@ -134,7 +134,7 @@ h3index_lt(PG_FUNCTION_ARGS)
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 	bool ret = *a < *b;
 	PG_FREE_IF_COPY(a, 0);
-	PG_FREE_IF_COPY(b, 0);
+	PG_FREE_IF_COPY(b, 1);
 	PG_RETURN_BOOL(ret);
 }
 
@@ -145,7 +145,7 @@ h3index_le(PG_FUNCTION_ARGS)
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 	bool ret = *a <= *b;
 	PG_FREE_IF_COPY(a, 0);
-	PG_FREE_IF_COPY(b, 0);
+	PG_FREE_IF_COPY(b, 1);
 	PG_RETURN_BOOL(ret);
 }
 
@@ -156,7 +156,7 @@ h3index_gt(PG_FUNCTION_ARGS)
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 	bool ret = *a > *b;
 	PG_FREE_IF_COPY(a, 0);
-	PG_FREE_IF_COPY(b, 0);
+	PG_FREE_IF_COPY(b, 1);
 	PG_RETURN_BOOL(ret);
 }
 
@@ -167,7 +167,7 @@ h3index_ge(PG_FUNCTION_ARGS)
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 	bool ret = *a >= *b;
 	PG_FREE_IF_COPY(a, 0);
-	PG_FREE_IF_COPY(b, 0);
+	PG_FREE_IF_COPY(b, 1);
 	PG_RETURN_BOOL(ret);
 }
 
@@ -179,7 +179,7 @@ h3index_overlaps(PG_FUNCTION_ARGS)
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 	bool ret = containment(a, b) != 0;
 	PG_FREE_IF_COPY(a, 0);
-	PG_FREE_IF_COPY(b, 0);
+	PG_FREE_IF_COPY(b, 1);
 	PG_RETURN_BOOL(ret);
 }
 
@@ -190,7 +190,7 @@ h3index_contains(PG_FUNCTION_ARGS)
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 	bool ret = containment(a, b) > 0;
 	PG_FREE_IF_COPY(a, 0);
-	PG_FREE_IF_COPY(b, 0);
+	PG_FREE_IF_COPY(b, 1);
 	PG_RETURN_BOOL(ret);
 }
 
@@ -201,6 +201,6 @@ h3index_contained_by(PG_FUNCTION_ARGS)
 	H3Index    *b = PG_GETARG_H3_INDEX_P(1);
 	bool ret = containment(a, b) < 0;
 	PG_FREE_IF_COPY(a, 0);
-	PG_FREE_IF_COPY(b, 0);
+	PG_FREE_IF_COPY(b, 1);
 	PG_RETURN_BOOL(ret);
 }

--- a/src/uniedges.c
+++ b/src/uniedges.c
@@ -39,7 +39,8 @@ h3_indexes_are_neighbors(PG_FUNCTION_ARGS)
 	H3Index    *origin = PG_GETARG_H3_INDEX_P(0);
 	H3Index    *destination = PG_GETARG_H3_INDEX_P(1);
 	bool		areNeighbors = h3IndexesAreNeighbors(*origin, *destination);
-
+	PG_FREE_IF_COPY(origin, 0);
+	PG_FREE_IF_COPY(destination, 1);
 	PG_RETURN_BOOL(areNeighbors);
 }
 
@@ -56,7 +57,8 @@ h3_get_h3_unidirectional_edge(PG_FUNCTION_ARGS)
 
 	*edge = getH3UnidirectionalEdge(*origin, *destination);
 	ASSERT_EXTERNAL(*edge, "Can only create edges between neighbouring indexes");
-
+	PG_FREE_IF_COPY(origin, 0);
+	PG_FREE_IF_COPY(destination, 1);
 	PG_RETURN_H3_INDEX_P(edge);
 }
 
@@ -66,7 +68,7 @@ h3_unidirectional_edge_is_valid(PG_FUNCTION_ARGS)
 {
 	H3Index    *edge = PG_GETARG_H3_INDEX_P(0);
 	bool		isValid = h3UnidirectionalEdgeIsValid(*edge);
-
+	PG_FREE_IF_COPY(edge, 0);
 	PG_RETURN_BOOL(isValid);
 }
 
@@ -78,7 +80,8 @@ h3_get_origin_h3_index_from_unidirectional_edge(PG_FUNCTION_ARGS)
 	H3Index    *origin = palloc(sizeof(H3Index));
 
 	*origin = getOriginH3IndexFromUnidirectionalEdge(*edge);
-
+	PG_FREE_IF_COPY(edge, 0);
+	PG_FREE_IF_COPY(origin, 1);
 	PG_RETURN_H3_INDEX_P(origin);
 }
 
@@ -90,6 +93,7 @@ h3_get_destination_h3_index_from_unidirectional_edge(PG_FUNCTION_ARGS)
 	H3Index    *destination = palloc(sizeof(H3Index));
 
 	*destination = getDestinationH3IndexFromUnidirectionalEdge(*edge);
+	PG_FREE_IF_COPY(edge, 0);
 	PG_RETURN_H3_INDEX_P(destination);
 }
 
@@ -118,6 +122,7 @@ h3_get_h3_indexes_from_unidirectional_edge(PG_FUNCTION_ARGS)
 
 	tuple = heap_form_tuple(tuple_desc, values, nulls);
 	result = HeapTupleGetDatum(tuple);
+	PG_FREE_IF_COPY(edge, 0);
 	PG_RETURN_DATUM(result);
 }
 
@@ -139,6 +144,7 @@ h3_get_h3_unidirectional_edges_from_hexagon(PG_FUNCTION_ARGS)
 
 		funcctx->user_fctx = edges;
 		funcctx->max_calls = maxSize;
+		PG_FREE_IF_COPY(origin, 0);
 		MemoryContextSwitchTo(oldcontext);
 	}
 
@@ -167,6 +173,6 @@ h3_get_h3_unidirectional_edge_boundary(PG_FUNCTION_ARGS)
 		polygon->p[v].x = radsToDegs(geoBoundary.verts[v].lat);
 		polygon->p[v].y = radsToDegs(geoBoundary.verts[v].lon);
 	}
-
+	PG_FREE_IF_COPY(edge, 0);
 	PG_RETURN_POLYGON_P(polygon);
 }

--- a/src/uniedges.c
+++ b/src/uniedges.c
@@ -81,7 +81,6 @@ h3_get_origin_h3_index_from_unidirectional_edge(PG_FUNCTION_ARGS)
 
 	*origin = getOriginH3IndexFromUnidirectionalEdge(*edge);
 	PG_FREE_IF_COPY(edge, 0);
-	PG_FREE_IF_COPY(origin, 1);
 	PG_RETURN_H3_INDEX_P(origin);
 }
 


### PR DESCRIPTION
Mentally debugging memory consumption. PostGIS does free-if-copy dance here so why not also do it in H3?