### PR TITLE
Check latitude and longitude validity in h3_geo_to_h3 function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ avoid adding features or APIs which do not map onto the
 
 </details>
 
+- Add input validation in geoToH3 (see [#41], thanks [@trylinka])
+
 ## [3.6.5] - 2020-08-14
 
 - Add support for partitioning by hash (see [#37], thanks [@abelvm])
@@ -163,6 +165,8 @@ avoid adding features or APIs which do not map onto the
 [#26]: https://github.com/bytesandbrains/h3-pg/pull/26
 [#37]: https://github.com/bytesandbrains/h3-pg/issues/37
 [#38]: https://github.com/bytesandbrains/h3-pg/issues/38
+[#41]: https://github.com/bytesandbrains/h3-pg/issues/41
 [@abelvm]: https://github.com/AbelVM
 [@komzpa]: https://github.com/Komzpa
 [@kmacdough]: https://github.com/kmacdough
+[@trylinka]: https://github.com/trylinka

--- a/sql/install/01-indexing.sql
+++ b/sql/install/01-indexing.sql
@@ -19,9 +19,9 @@
 -- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 
 -- Availability: 0.2.0
-CREATE OR REPLACE FUNCTION h3_geo_to_h3(point, resolution integer) RETURNS h3index
+CREATE OR REPLACE FUNCTION h3_geo_to_h3(point, resolution integer, strict BOOLEAN default FALSE) RETURNS h3index
     AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-    COMMENT ON FUNCTION h3_geo_to_h3(point, resolution integer) IS
+    COMMENT ON FUNCTION h3_geo_to_h3(point, resolution integer, boolean) IS
 'Indexes the location at the specified resolution';
 
 -- Availability: 1.0.0

--- a/sql/install/99-postgis.sql
+++ b/sql/install/99-postgis.sql
@@ -19,12 +19,12 @@
 -- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 
 -- Availability: 0.3.0
-CREATE OR REPLACE FUNCTION h3_geo_to_h3(geometry, resolution integer) RETURNS h3index
-    AS $$ SELECT h3_geo_to_h3(ST_Transform($1, 4326)::point, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION h3_geo_to_h3(geometry, resolution integer, strict BOOLEAN default FALSE) RETURNS h3index
+    AS $$ SELECT h3_geo_to_h3($1::point, $2, $3); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 
 -- Availability: 0.3.0
-CREATE OR REPLACE FUNCTION h3_geo_to_h3(geography, resolution integer) RETURNS h3index
-    AS $$ SELECT h3_geo_to_h3($1::geometry, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION h3_geo_to_h3(geography, resolution integer, strict BOOLEAN default FALSE) RETURNS h3index
+    AS $$ SELECT h3_geo_to_h3($1::geometry, $2, $3); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 
 -- Availability: 1.0.0
 CREATE OR REPLACE FUNCTION h3_to_geometry(h3index) RETURNS geometry

--- a/sql/install/99-postgis.sql
+++ b/sql/install/99-postgis.sql
@@ -20,7 +20,7 @@
 
 -- Availability: 0.3.0
 CREATE OR REPLACE FUNCTION h3_geo_to_h3(geometry, resolution integer) RETURNS h3index
-    AS $$ SELECT h3_geo_to_h3($1::point, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+    AS $$ SELECT h3_geo_to_h3(ST_Transform($1, 4326)::point, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 
 -- Availability: 0.3.0
 CREATE OR REPLACE FUNCTION h3_geo_to_h3(geography, resolution integer) RETURNS h3index

--- a/sql/updates/h3--3.6.5--unreleased.sql
+++ b/sql/updates/h3--3.6.5--unreleased.sql
@@ -29,3 +29,17 @@ CREATE OR REPLACE FUNCTION h3_to_geometry(h3index) RETURNS geometry
   AS $$ SELECT ST_SetSRID(h3_to_geo($1)::geometry, 4326) $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION h3_to_geography(h3index) RETURNS geography
   AS $$ SELECT h3_to_geometry($1)::geography $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+
+DROP FUNCTION IF EXISTS h3_geo_to_h3(point, integer);
+CREATE OR REPLACE FUNCTION h3_geo_to_h3(point, resolution integer, strict BOOLEAN default FALSE) RETURNS h3index
+    AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+    COMMENT ON FUNCTION h3_geo_to_h3(point, integer, boolean) IS
+'Indexes the location at the specified resolution';
+
+DROP FUNCTION IF EXISTS h3_geo_to_h3(geometry, integer);
+CREATE OR REPLACE FUNCTION h3_geo_to_h3(geometry, resolution integer, strict BOOLEAN default FALSE) RETURNS h3index
+    AS $$ SELECT h3_geo_to_h3($1::point, $2, $3); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+
+DROP FUNCTION IF EXISTS h3_geo_to_h3(geography, integer);
+CREATE OR REPLACE FUNCTION h3_geo_to_h3(geography, resolution integer, strict BOOLEAN default FALSE) RETURNS h3index
+    AS $$ SELECT h3_geo_to_h3($1::geometry, $2, $3); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -32,9 +32,16 @@ h3_geo_to_h3(PG_FUNCTION_ARGS)
 {
 	Point	   *geo = PG_GETARG_POINT_P(0);
 	int			resolution = PG_GETARG_INT32(1);
+	bool		strict = PG_GETARG_BOOL(2);
 
 	H3Index		idx;
 	GeoCoord	location;
+
+	if (strict)
+	{
+		ASSERT_EXTERNAL(geo->x >= -180 && geo->x <= 180, "Longitude must be between -180 and 180 degrees inclusive, but got %f.", geo->x);
+		ASSERT_EXTERNAL(geo->y >= -90 && geo->y <= 90, "Latitude must be between -90 and 90 degrees inclusive, but got %f.", geo->y);
+	}
 
 	location.lon = degsToRads(geo->x);
 	location.lat = degsToRads(geo->y);

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -36,9 +36,6 @@ h3_geo_to_h3(PG_FUNCTION_ARGS)
 	H3Index		idx;
 	GeoCoord	location;
 
-    ASSERT_EXTERNAL(geo->x >= -180 && geo->x <= 180, "Longitude must be between -180 and 180 degrees inclusive, but got %f.", geo->x);
-    ASSERT_EXTERNAL(geo->y >= -90 && geo->y <= 90, "Latitude must be between -90 and 90 degrees inclusive, but got %f.", geo->y);
-
 	location.lon = degsToRads(geo->x);
 	location.lat = degsToRads(geo->y);
 

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -36,6 +36,9 @@ h3_geo_to_h3(PG_FUNCTION_ARGS)
 	H3Index		idx;
 	GeoCoord	location;
 
+    ASSERT_EXTERNAL(geo->x >= -180 && geo->x <= 180, "Longitude must be between -180 and 180 degrees inclusive, but got %f.", geo->x);
+    ASSERT_EXTERNAL(geo->y >= -90 && geo->y <= 90, "Latitude must be between -90 and 90 degrees inclusive, but got %f.", geo->y);
+
 	location.lon = degsToRads(geo->x);
 	location.lat = degsToRads(geo->y);
 

--- a/test/expected/postgis.out
+++ b/test/expected/postgis.out
@@ -4,28 +4,42 @@
 \set hexagon '\'8a63a9a99047fff\''
 \set meter ST_SetSRID(ST_Point(6196902.235389061,1413172.0833316022), 3857)
 \set degree ST_SetSRID(ST_Point(55.6677199224442,12.592131261648213), 4326)
-SELECT h3_geo_to_h3(:meter, :resolution) = '8a63a9a99047fff';
- t
-
 SELECT h3_geo_to_h3(:degree, :resolution) = '8a63a9a99047fff';
  t
 
+-- meters are NOT reprojected
+SELECT h3_geo_to_h3(:meter, :resolution) <> '8a63a9a99047fff';
+ t
+
+-- check back/forth conversion return same hex
 SELECT h3_geo_to_h3(h3_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';
  t
 
+-- check num points in boundary
 SELECT ST_NPoints( h3_to_geo_boundary_geometry(:hexagon)) = 7;
  t
 
--- test h3_geo_to_h3 throws for srid-less geometry
+-- test strict h3_geo_to_h3 throws for bad latlon
 CREATE FUNCTION h3_test_postgis_nounit() RETURNS boolean LANGUAGE PLPGSQL
     AS $$
         BEGIN
-            PERFORM h3_geo_to_h3(ST_Point(6196902, 1413172), 1);
+            PERFORM h3_geo_to_h3(POINT(360, 2.592131261648213), 1, true);
             RETURN false;
         EXCEPTION WHEN OTHERS THEN
             RETURN true;
         END;
     $$;
 SELECT h3_test_postgis_nounit();
+ t
+
+-- Test wraparound
+\set lon 55.6677199224442
+\set lat 12.592131261648213
+SELECT h3_geo_to_h3(POINT(:lon,       :lat), 7)
+     = h3_geo_to_h3(POINT(:lon + 360, :lat), 7);
+ t
+
+SELECT h3_geo_to_h3(POINT(:lon, :lat      ), 7)
+     = h3_geo_to_h3(POINT(:lon, :lat + 360), 7);
  t
 

--- a/test/expected/postgis.out
+++ b/test/expected/postgis.out
@@ -2,9 +2,30 @@
 -- Variables for testing
 \set resolution 10
 \set hexagon '\'8a63a9a99047fff\''
-SELECT h3_geo_to_h3(h3_to_geo(:hexagon)::geometry, :resolution) = '8a63a9a99047fff';
+\set meter ST_SetSRID(ST_Point(6196902.235389061,1413172.0833316022), 3857)
+\set degree ST_SetSRID(ST_Point(55.6677199224442,12.592131261648213), 4326)
+SELECT h3_geo_to_h3(:meter, :resolution) = '8a63a9a99047fff';
+ t
+
+SELECT h3_geo_to_h3(:degree, :resolution) = '8a63a9a99047fff';
+ t
+
+SELECT h3_geo_to_h3(h3_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';
  t
 
 SELECT ST_NPoints( h3_to_geo_boundary_geometry(:hexagon)) = 7;
+ t
+
+-- test h3_geo_to_h3 throws for srid-less geometry
+CREATE FUNCTION h3_test_postgis_nounit() RETURNS boolean LANGUAGE PLPGSQL
+    AS $$
+        BEGIN
+            PERFORM h3_geo_to_h3(ST_Point(6196902, 1413172), 1);
+            RETURN false;
+        EXCEPTION WHEN OTHERS THEN
+            RETURN true;
+        END;
+    $$;
+SELECT h3_test_postgis_nounit();
  t
 

--- a/test/sql/postgis.sql
+++ b/test/sql/postgis.sql
@@ -2,7 +2,25 @@
 -- Variables for testing
 \set resolution 10
 \set hexagon '\'8a63a9a99047fff\''
+\set meter ST_SetSRID(ST_Point(6196902.235389061,1413172.0833316022), 3857)
+\set degree ST_SetSRID(ST_Point(55.6677199224442,12.592131261648213), 4326)
 
-SELECT h3_geo_to_h3(h3_to_geo(:hexagon)::geometry, :resolution) = '8a63a9a99047fff';
+SELECT h3_geo_to_h3(:meter, :resolution) = '8a63a9a99047fff';
+SELECT h3_geo_to_h3(:degree, :resolution) = '8a63a9a99047fff';
+
+SELECT h3_geo_to_h3(h3_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';
 
 SELECT ST_NPoints( h3_to_geo_boundary_geometry(:hexagon)) = 7;
+
+-- test h3_geo_to_h3 throws for srid-less geometry
+CREATE FUNCTION h3_test_postgis_nounit() RETURNS boolean LANGUAGE PLPGSQL
+    AS $$
+        BEGIN
+            PERFORM h3_geo_to_h3(ST_Point(6196902, 1413172), 1);
+            RETURN false;
+        EXCEPTION WHEN OTHERS THEN
+            RETURN true;
+        END;
+    $$;
+
+SELECT h3_test_postgis_nounit();

--- a/test/sql/postgis.sql
+++ b/test/sql/postgis.sql
@@ -24,3 +24,11 @@ CREATE FUNCTION h3_test_postgis_nounit() RETURNS boolean LANGUAGE PLPGSQL
     $$;
 
 SELECT h3_test_postgis_nounit();
+
+\set lon 55.6677199224442
+\set lat 12.592131261648213
+SELECT h3_geo_to_h3(POINT(:lon,       :lat), 7)
+     = h3_geo_to_h3(POINT(:lon + 360, :lat), 7);
+
+SELECT h3_geo_to_h3(POINT(:lon, :lat      ), 7)
+     = h3_geo_to_h3(POINT(:lon, :lat + 360), 7);

--- a/test/sql/postgis.sql
+++ b/test/sql/postgis.sql
@@ -5,18 +5,22 @@
 \set meter ST_SetSRID(ST_Point(6196902.235389061,1413172.0833316022), 3857)
 \set degree ST_SetSRID(ST_Point(55.6677199224442,12.592131261648213), 4326)
 
-SELECT h3_geo_to_h3(:meter, :resolution) = '8a63a9a99047fff';
 SELECT h3_geo_to_h3(:degree, :resolution) = '8a63a9a99047fff';
 
+-- meters are NOT reprojected
+SELECT h3_geo_to_h3(:meter, :resolution) <> '8a63a9a99047fff';
+
+-- check back/forth conversion return same hex
 SELECT h3_geo_to_h3(h3_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';
 
+-- check num points in boundary
 SELECT ST_NPoints( h3_to_geo_boundary_geometry(:hexagon)) = 7;
 
--- test h3_geo_to_h3 throws for srid-less geometry
+-- test strict h3_geo_to_h3 throws for bad latlon
 CREATE FUNCTION h3_test_postgis_nounit() RETURNS boolean LANGUAGE PLPGSQL
     AS $$
         BEGIN
-            PERFORM h3_geo_to_h3(ST_Point(6196902, 1413172), 1);
+            PERFORM h3_geo_to_h3(POINT(360, 2.592131261648213), 1, true);
             RETURN false;
         EXCEPTION WHEN OTHERS THEN
             RETURN true;
@@ -25,6 +29,7 @@ CREATE FUNCTION h3_test_postgis_nounit() RETURNS boolean LANGUAGE PLPGSQL
 
 SELECT h3_test_postgis_nounit();
 
+-- Test wraparound
 \set lon 55.6677199224442
 \set lat 12.592131261648213
 SELECT h3_geo_to_h3(POINT(:lon,       :lat), 7)


### PR DESCRIPTION
h3_geo_to_h3 function takes to input point. If we use point, we consider that point is measured into degree values. The main problem that there is no checking that point is within longitude and latitude values. This validation check input coordinates to see if their values make a sense in degrees. 

`but got %f.", geo->x` added for checking in logs value that function got. 