### PR TITLE
h3_polyfill: allow >1Gb memory allocations

### DIFF
--- a/h3/src/lib/regions.c
+++ b/h3/src/lib/regions.c
@@ -130,7 +130,8 @@ h3_polyfill(PG_FUNCTION_ARGS)
 
 		/* produce hexagons into allocated memory */
 		maxSize = maxPolyfillSize(&polygon, resolution);
-		indices = palloc0(maxSize * sizeof(H3Index));
+		indices = palloc_extended(maxSize * sizeof(H3Index),
+								  MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
 		polyfill(&polygon, resolution, indices);
 
 		funcctx->user_fctx = indices;


### PR DESCRIPTION
Fixes "h3_polyfill crashes PostgreSQL on random geometry" https://github.com/bytesandbrains/h3-pg/issues/56