### PR TITLE
Enable link time optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ EXTRA_CLEAN += \
 
 # PGXS boilerplate
 PG_CONFIG = pg_config
+CUSTOM_COPT=-flto -mpc64
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
@@ -81,7 +82,7 @@ $(LIBH3_BUILD): $(LIBH3_SOURCE)
 	mkdir -p $(LIBH3_BUILD)
 	cd $(LIBH3_BUILD) && cmake \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_C_FLAGS=-fPIC \
+		-DCMAKE_C_FLAGS="-fPIC -fvisibility=hidden -flto -fwrapv -mpc64" \
 		-DBUILD_TESTING=OFF \
 		-DENABLE_COVERAGE=OFF \
 		-DENABLE_DOCS=OFF \


### PR DESCRIPTION
Enabling link time optimization for h3-pg/h3 improves performance by ~12--15%.

Test query:
```
WITH coords AS (SELECT * from generate_series(-85, 85, 0.1) AS lat, generate_series(-180, 180, 0.2) AS lon)
SELECT h3_to_geo_boundary(h3_geo_to_h3(point(lon, lat), 8))
```

Added compilation flags:
* `-flto` enables LTO;
* `-fvisibility=hidden` allows to inline H3 library functions in h3-pg (not allowed with default visibility since definitions can change at link time in this case);
* `-fwrapv` allows to inline functions like `degsToRads`/`radsToDegs` (PGXS compiles extension with `-fwrapv`);
* `-mpc64` mitigates effect of extened floating point precision on x86 (using x87) and also improves performance by ~2--5%

Without `-mpc64`, LTO (inlining specifically?) causes subtle differences in floating point calculation results on x86, several tests failing for both h3-pg and h3 library. `-fexcess-presicion=standard` and `-ffloat-store` do not solve this problem completely.
Another possible solution would be to use SSE with `mfpmath=sse -msse2`.