### PR TITLE
fix: btree comparator returns wrong sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ avoid adding features or APIs which do not map onto the
 - Fix SP-GiST picksplit crash when tree depth exceeds cell resolution (see [#187], thanks [@yocontra])
 - Fix SP-GiST picksplit using wrong prefix when batch has mixed parents, silently dropping containment query results (see [#189], thanks [@yocontra])
 - Fix `<@` operator and SP-GiST returning false for self-containment (see [#191], thanks [@yocontra])
+- ⚠️ Fix btree comparator returning wrong sign, causing reversed `ORDER BY` and incorrect range scans; upgrade auto-reindexes affected indexes (see [#190], thanks [@yocontra])
 - Add experimental GiST operator class (see [#188], initial work in [#42], thanks [@zachasme], [@yocontra], [@Komzpa], [@AbelVM], and [@mattiZed])
 - Fix PostgreSQL 17+ maintenance-operation failures for `h3_postgis` SQL wrappers by schema-qualifying extension object references (see [#165], [#168])
 - Add `h3_postgis` regression coverage for `CREATE INDEX` expression functions and materialized view maintenance under restricted `search_path`

--- a/h3/sql/updates/h3--4.2.3--unreleased.sql
+++ b/h3/sql/updates/h3--4.2.3--unreleased.sql
@@ -147,6 +147,7 @@ BEGIN
         JOIN pg_am am ON am.oid = ci.relam
         JOIN pg_opclass opc ON opc.oid = ANY(i.indclass)
         WHERE am.amname = 'btree'
+          AND ci.relkind = 'i'
           AND opc.opcname = 'h3index_ops'
     LOOP
         EXECUTE format('REINDEX INDEX %s', r.idx);

--- a/h3/sql/updates/h3--4.2.3--unreleased.sql
+++ b/h3/sql/updates/h3--4.2.3--unreleased.sql
@@ -132,8 +132,8 @@ $$;
 -- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 -- Btree comparator sign fix: existing btree indexes on h3index columns are
 -- physically sorted in the wrong order.  REINDEX every btree index that uses
--- the h3index_ops operator class so the on-disk sort matches the corrected
--- comparator.
+-- the h3index_ops operator class (in any column position) so the on-disk sort
+-- matches the corrected comparator.
 -- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 
 DO $$
@@ -141,11 +141,11 @@ DECLARE
     r RECORD;
 BEGIN
     FOR r IN
-        SELECT ci.oid::regclass AS idx
+        SELECT DISTINCT ci.oid::regclass AS idx
         FROM pg_index i
         JOIN pg_class ci ON ci.oid = i.indexrelid
         JOIN pg_am am ON am.oid = ci.relam
-        JOIN pg_opclass opc ON opc.oid = i.indclass[0]
+        JOIN pg_opclass opc ON opc.oid = ANY(i.indclass)
         WHERE am.amname = 'btree'
           AND opc.opcname = 'h3index_ops'
     LOOP

--- a/h3/sql/updates/h3--4.2.3--unreleased.sql
+++ b/h3/sql/updates/h3--4.2.3--unreleased.sql
@@ -130,6 +130,31 @@ END
 $$;
 
 -- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+-- Btree comparator sign fix: existing btree indexes on h3index columns are
+-- physically sorted in the wrong order.  REINDEX every btree index that uses
+-- the h3index_ops operator class so the on-disk sort matches the corrected
+-- comparator.
+-- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT ci.oid::regclass AS idx
+        FROM pg_index i
+        JOIN pg_class ci ON ci.oid = i.indexrelid
+        JOIN pg_am am ON am.oid = ci.relam
+        JOIN pg_opclass opc ON opc.oid = i.indclass[0]
+        WHERE am.amname = 'btree'
+          AND opc.opcname = 'h3index_ops'
+    LOOP
+        EXECUTE format('REINDEX INDEX %s', r.idx);
+    END LOOP;
+END
+$$;
+
+-- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 -- GiST Operator Class (opclass_gist.c)
 -- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 

--- a/h3/src/opclass_btree.c
+++ b/h3/src/opclass_btree.c
@@ -30,12 +30,12 @@ h3index_cmp(PG_FUNCTION_ARGS)
 	H3Index		a = PG_GETARG_H3INDEX(0);
 	H3Index		b = PG_GETARG_H3INDEX(1);
 
-	uint32_t	ret = 0;
+	int32_t		ret = 0;
 
 	if (a < b)
-		ret = 1;
-	else if (a > b)
 		ret = -1;
+	else if (a > b)
+		ret = 1;
 
 	PG_RETURN_INT32(ret);
 }
@@ -47,9 +47,9 @@ h3index_cmp_abbrev(Datum x, Datum y, SortSupport ssup)
 	if (x == y)
 		return 0;
 	else if (x < y)
-		return 1;
-	else
 		return -1;
+	else
+		return 1;
 }
 
 static int
@@ -61,8 +61,8 @@ h3index_cmp_full(Datum x, Datum y, SortSupport ssup)
 	if (a == b)
 		return 0;
 	else if (a < b)
-		return 1;
-	return -1;
+		return -1;
+	return 1;
 }
 
 static bool

--- a/h3/test/expected/opclass_btree.out
+++ b/h3/test/expected/opclass_btree.out
@@ -12,3 +12,73 @@ SELECT hex = :hexagon FROM (
 ) q;
  t
 
+--
+-- TEST ORDER BY uses correct sort direction
+-- The first cell in ascending uint64 order should be less than the last.
+-- If the comparator is inverted, ORDER BY ASC would produce descending order.
+--
+SELECT first < last FROM (
+  SELECT
+    (SELECT hex FROM h3_test_btree ORDER BY hex ASC LIMIT 1) AS first,
+    (SELECT hex FROM h3_test_btree ORDER BY hex DESC LIMIT 1) AS last
+) q;
+ t
+
+--
+-- TEST range scans: cross-validate index scan vs seq scan
+-- Pick a pivot cell and count how many cells are greater/less than it.
+--
+SET enable_seqscan = off;
+SELECT COUNT(*) AS idx_gt INTO TEMP btree_idx_gt
+  FROM h3_test_btree WHERE hex > :hexagon;
+SELECT COUNT(*) AS idx_lt INTO TEMP btree_idx_lt
+  FROM h3_test_btree WHERE hex < :hexagon;
+RESET enable_seqscan;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SELECT COUNT(*) AS seq_gt INTO TEMP btree_seq_gt
+  FROM h3_test_btree WHERE hex > :hexagon;
+SELECT COUNT(*) AS seq_lt INTO TEMP btree_seq_lt
+  FROM h3_test_btree WHERE hex < :hexagon;
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+-- Index and seq scan must agree on counts
+SELECT i.idx_gt = s.seq_gt FROM btree_idx_gt i, btree_seq_gt s;
+ t
+
+SELECT i.idx_lt = s.seq_lt FROM btree_idx_lt i, btree_seq_lt s;
+ t
+
+-- Both should be non-zero (our pivot is not the min or max)
+SELECT i.idx_gt > 0 FROM btree_idx_gt i;
+ t
+
+SELECT i.idx_lt > 0 FROM btree_idx_lt i;
+ t
+
+-- gt + lt + 1 (the pivot itself) should equal the total row count
+SELECT i.idx_gt + j.idx_lt + 1 = (SELECT COUNT(*) FROM h3_test_btree)
+  FROM btree_idx_gt i, btree_idx_lt j;
+ t
+
+DROP TABLE btree_idx_gt, btree_idx_lt, btree_seq_gt, btree_seq_lt;
+--
+-- TEST BETWEEN via index
+--
+SET enable_seqscan = off;
+SELECT COUNT(*) AS idx_between INTO TEMP btree_idx_bw
+  FROM h3_test_btree WHERE hex BETWEEN '8001fffffffffff'::h3index AND '8005fffffffffff'::h3index;
+RESET enable_seqscan;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SELECT COUNT(*) AS seq_between INTO TEMP btree_seq_bw
+  FROM h3_test_btree WHERE hex BETWEEN '8001fffffffffff'::h3index AND '8005fffffffffff'::h3index;
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+SELECT i.idx_between = s.seq_between FROM btree_idx_bw i, btree_seq_bw s;
+ t
+
+SELECT i.idx_between > 0 FROM btree_idx_bw i;
+ t
+
+DROP TABLE btree_idx_bw, btree_seq_bw;

--- a/h3/test/expected/opclass_btree.out
+++ b/h3/test/expected/opclass_btree.out
@@ -1,9 +1,9 @@
 \pset tuples_only on
 \set string '\'801dfffffffffff\''
 \set hexagon ':string::h3index'
-CREATE TABLE h3_test_btree (hex h3index PRIMARY KEY);
+CREATE TABLE h3_test_btree (hex h3index NOT NULL);
 INSERT INTO h3_test_btree (hex) SELECT * from h3_get_res_0_cells();
-CREATE INDEX h3_btree ON h3_test_btree USING btree (hex);
+CREATE UNIQUE INDEX h3_btree ON h3_test_btree USING btree (hex);
 --
 -- TEST b-tree operator class
 --
@@ -16,7 +16,12 @@ SELECT hex = :hexagon FROM (
 -- TEST ORDER BY uses correct sort direction
 -- The first cell in ascending uint64 order should be less than the last.
 -- If the comparator is inverted, ORDER BY ASC would produce descending order.
+-- Disable index scans so the planner must use a tuplesort, which exercises
+-- h3index_cmp_abbrev and h3index_cmp_full directly.
 --
+SET enable_indexscan = off;
+SET enable_indexonlyscan = off;
+SET enable_bitmapscan = off;
 SELECT first < last FROM (
   SELECT
     (SELECT hex FROM h3_test_btree ORDER BY hex ASC LIMIT 1) AS first,
@@ -24,6 +29,9 @@ SELECT first < last FROM (
 ) q;
  t
 
+RESET enable_indexscan;
+RESET enable_indexonlyscan;
+RESET enable_bitmapscan;
 --
 -- TEST range scans: cross-validate index scan vs seq scan
 -- Pick a pivot cell and count how many cells are greater/less than it.

--- a/h3/test/sql/opclass_btree.sql
+++ b/h3/test/sql/opclass_btree.sql
@@ -11,3 +11,67 @@ CREATE INDEX h3_btree ON h3_test_btree USING btree (hex);
 SELECT hex = :hexagon FROM (
     SELECT hex FROM h3_test_btree WHERE hex = :hexagon
 ) q;
+
+--
+-- TEST ORDER BY uses correct sort direction
+-- The first cell in ascending uint64 order should be less than the last.
+-- If the comparator is inverted, ORDER BY ASC would produce descending order.
+--
+SELECT first < last FROM (
+  SELECT
+    (SELECT hex FROM h3_test_btree ORDER BY hex ASC LIMIT 1) AS first,
+    (SELECT hex FROM h3_test_btree ORDER BY hex DESC LIMIT 1) AS last
+) q;
+
+--
+-- TEST range scans: cross-validate index scan vs seq scan
+-- Pick a pivot cell and count how many cells are greater/less than it.
+--
+SET enable_seqscan = off;
+SELECT COUNT(*) AS idx_gt INTO TEMP btree_idx_gt
+  FROM h3_test_btree WHERE hex > :hexagon;
+SELECT COUNT(*) AS idx_lt INTO TEMP btree_idx_lt
+  FROM h3_test_btree WHERE hex < :hexagon;
+RESET enable_seqscan;
+
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SELECT COUNT(*) AS seq_gt INTO TEMP btree_seq_gt
+  FROM h3_test_btree WHERE hex > :hexagon;
+SELECT COUNT(*) AS seq_lt INTO TEMP btree_seq_lt
+  FROM h3_test_btree WHERE hex < :hexagon;
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+
+-- Index and seq scan must agree on counts
+SELECT i.idx_gt = s.seq_gt FROM btree_idx_gt i, btree_seq_gt s;
+SELECT i.idx_lt = s.seq_lt FROM btree_idx_lt i, btree_seq_lt s;
+
+-- Both should be non-zero (our pivot is not the min or max)
+SELECT i.idx_gt > 0 FROM btree_idx_gt i;
+SELECT i.idx_lt > 0 FROM btree_idx_lt i;
+
+-- gt + lt + 1 (the pivot itself) should equal the total row count
+SELECT i.idx_gt + j.idx_lt + 1 = (SELECT COUNT(*) FROM h3_test_btree)
+  FROM btree_idx_gt i, btree_idx_lt j;
+
+DROP TABLE btree_idx_gt, btree_idx_lt, btree_seq_gt, btree_seq_lt;
+
+--
+-- TEST BETWEEN via index
+--
+SET enable_seqscan = off;
+SELECT COUNT(*) AS idx_between INTO TEMP btree_idx_bw
+  FROM h3_test_btree WHERE hex BETWEEN '8001fffffffffff'::h3index AND '8005fffffffffff'::h3index;
+RESET enable_seqscan;
+
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SELECT COUNT(*) AS seq_between INTO TEMP btree_seq_bw
+  FROM h3_test_btree WHERE hex BETWEEN '8001fffffffffff'::h3index AND '8005fffffffffff'::h3index;
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+
+SELECT i.idx_between = s.seq_between FROM btree_idx_bw i, btree_seq_bw s;
+SELECT i.idx_between > 0 FROM btree_idx_bw i;
+DROP TABLE btree_idx_bw, btree_seq_bw;

--- a/h3/test/sql/opclass_btree.sql
+++ b/h3/test/sql/opclass_btree.sql
@@ -2,9 +2,9 @@
 \set string '\'801dfffffffffff\''
 \set hexagon ':string::h3index'
 
-CREATE TABLE h3_test_btree (hex h3index PRIMARY KEY);
+CREATE TABLE h3_test_btree (hex h3index NOT NULL);
 INSERT INTO h3_test_btree (hex) SELECT * from h3_get_res_0_cells();
-CREATE INDEX h3_btree ON h3_test_btree USING btree (hex);
+CREATE UNIQUE INDEX h3_btree ON h3_test_btree USING btree (hex);
 --
 -- TEST b-tree operator class
 --
@@ -16,12 +16,20 @@ SELECT hex = :hexagon FROM (
 -- TEST ORDER BY uses correct sort direction
 -- The first cell in ascending uint64 order should be less than the last.
 -- If the comparator is inverted, ORDER BY ASC would produce descending order.
+-- Disable index scans so the planner must use a tuplesort, which exercises
+-- h3index_cmp_abbrev and h3index_cmp_full directly.
 --
+SET enable_indexscan = off;
+SET enable_indexonlyscan = off;
+SET enable_bitmapscan = off;
 SELECT first < last FROM (
   SELECT
     (SELECT hex FROM h3_test_btree ORDER BY hex ASC LIMIT 1) AS first,
     (SELECT hex FROM h3_test_btree ORDER BY hex DESC LIMIT 1) AS last
 ) q;
+RESET enable_indexscan;
+RESET enable_indexonlyscan;
+RESET enable_bitmapscan;
 
 --
 -- TEST range scans: cross-validate index scan vs seq scan


### PR DESCRIPTION
## What's broken

The three btree comparator functions (`h3index_cmp`, `h3index_cmp_abbrev`, `h3index_cmp_full`) return 1 when `a < b` and -1 when `a > b`. PostgreSQL expects the opposite ([docs](https://www.postgresql.org/docs/current/btree-support-funcs.html): comparison support function must return negative when `a < b`, positive when `a > b`, same convention as `strcmp`/`qsort`).

The btree index ends up sorted in reverse, which means `ORDER BY hex ASC` produces descending order and merge joins can silently return wrong results. The existing test only checked equality (`WHERE hex = X`), which works fine since the comparator does return 0 for equal values.

## The fix

- Swap the return values in all three comparator functions
- Change `ret` from `uint32_t` to `int32_t` since it holds -1/0/1
- **Upgrade script**: automatically REINDEXes every btree index using `h3index_ops` so existing indexes match the corrected sort order

## Tests added

- ORDER BY ascending vs descending — verifies sort direction is correct
- Range scans (`>`, `<`) — cross-validates index scan vs seq scan counts
- Partition check — gt + lt + 1 = total rows
- BETWEEN — cross-validates index scan vs seq scan