### PR TITLE
Upgrade bundled H3 core to v4.5.0

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -34,4 +34,6 @@ jobs:
 
       - name: Print regression diffs
         if: ${{ failure() }}
-        run: cat build/*/test/regression.diffs || true
+        run: |
+          Get-ChildItem build -Recurse -Filter regression.diffs -ErrorAction SilentlyContinue |
+            ForEach-Object { Get-Content $_.FullName }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ avoid adding features or APIs which do not map onto the
 
 - [#188], Add experimental GiST operator class for `h3index`; initial work in [#42] ([Zacharias Knudsen], [Eric Schoffstall], [Darafei Praliaskouski], [Abel Vázquez Montoro], [@mattiZed])
 - Bump bundled H3 core library to `v4.4.1` and add bindings for new upstream APIs including `h3_grid_ring`, `h3_get_index_digit`, `h3_construct_cell`, and `h3_is_valid_index` ([Darafei Praliaskouski])
+- Bump bundled H3 core library to `v4.5.0`, expose `h3_reverse_directed_edge`, and inherit upstream bidirectional `h3_grid_path_cells` plus stricter cell-to-multipolygon validation ([Darafei Praliaskouski])
 
 * Breaking Changes *
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ project(
 # set this to "${PROJECT_VERSION}" on release
 #set(INSTALL_VERSION "${PROJECT_VERSION}")
 set(INSTALL_VERSION "unreleased")
-set(H3_CORE_VERSION 4.4.1)
-set(H3_CORE_SHA256 9df719eb878f218c203e424dc5ffca9b98eca4d78ba83928773987649ead404d)
+set(H3_CORE_VERSION 4.5.0)
+set(H3_CORE_SHA256 0da8a392a6ff77e76b60e6a331a49497d0935b6b7b6899da7a3e2786139b0441)
 
 # If you set any CMAKE_ variables, that can go here.
 # (But usually don't do this, except maybe for C++ standard)

--- a/cmake/AddPostgreSQLExtension.cmake
+++ b/cmake/AddPostgreSQLExtension.cmake
@@ -91,6 +91,9 @@ function(PostgreSQL_add_extension_bitcode LIBRARY_NAME EXTENSION_NAME EXTENSION_
     "-DPOSTGRESQL_VERSION_MAJOR=${PostgreSQL_VERSION_MAJOR}"
   )
   set(EXTENSION_BITCODE_COMPILE_ARGS "")
+  list(APPEND EXTENSION_BITCODE_COMPILE_ARGS ${PostgreSQL_BITCODE_COMPILER_FLAGS})
+  list(APPEND EXTENSION_BITCODE_COMPILE_ARGS ${PostgreSQL_BITCODE_CFLAGS})
+  list(APPEND EXTENSION_BITCODE_COMPILE_ARGS ${PostgreSQL_CPPFLAGS})
   if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     list(APPEND EXTENSION_BITCODE_COMPILE_ARGS "-fno-semantic-interposition")
   endif()
@@ -109,7 +112,6 @@ function(PostgreSQL_add_extension_bitcode LIBRARY_NAME EXTENSION_NAME EXTENSION_
       COMMAND ${PostgreSQL_LLVM_CLANG_BIN}
         -emit-llvm
         -c
-        -O2
         -flto=thin
         -fPIC
         ${EXTENSION_BITCODE_COMPILE_ARGS}

--- a/cmake/AddPostgreSQLExtension.cmake
+++ b/cmake/AddPostgreSQLExtension.cmake
@@ -186,6 +186,9 @@ function(PostgreSQL_add_extension LIBRARY_NAME)
 
     # Link extension to PostgreSQL
     target_link_libraries(${LIBRARY_NAME} PRIVATE PostgreSQL::PostgreSQL)
+    if(PostgreSQL_CPPFLAGS)
+      target_compile_options(${LIBRARY_NAME} PRIVATE ${PostgreSQL_CPPFLAGS})
+    endif()
 
     if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
       # Allow cross-TU optimization of internal calls inside the extension DSO.

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -38,6 +38,10 @@ execute_process(COMMAND ${PostgreSQL_CONFIG} --includedir-server OUTPUT_VARIABLE
 execute_process(COMMAND ${PostgreSQL_CONFIG} --libdir            OUTPUT_VARIABLE PostgreSQL_LIBRARY_DIR        OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND ${PostgreSQL_CONFIG} --pkglibdir         OUTPUT_VARIABLE PostgreSQL_PKG_LIBRARY_DIR    OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND ${PostgreSQL_CONFIG} --configure         OUTPUT_VARIABLE PostgreSQL_CONFIGURE          OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PostgreSQL_CONFIG} --cppflags          OUTPUT_VARIABLE PostgreSQL_CPPFLAGS_STRING    OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PostgreSQL_CONFIG} --pgxs              OUTPUT_VARIABLE PostgreSQL_PGXS               OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+separate_arguments(PostgreSQL_CPPFLAGS UNIX_COMMAND "${PostgreSQL_CPPFLAGS_STRING}")
 
 # PostgreSQL can optionally be built with LLVM support (`--with-llvm`).
 # We mirror that capability to optionally emit extension bitcode for JIT.
@@ -77,6 +81,53 @@ find_program(PostgreSQL_LLVM_LTO_BIN
   NAMES llvm-lto
   HINTS ${PostgreSQL_LLVM_HINTS}
 )
+
+# Mirror PostgreSQL's PGXS bitcode compiler flags when LLVM support is enabled.
+# The values live in Makefile.global rather than pg_config output.
+set(PostgreSQL_BITCODE_COMPILER_FLAGS "")
+set(PostgreSQL_BITCODE_CFLAGS "")
+if(PostgreSQL_WITH_LLVM AND PostgreSQL_PGXS)
+  get_filename_component(PostgreSQL_PGXS_MAKEFILES_DIR "${PostgreSQL_PGXS}" DIRECTORY)
+  get_filename_component(PostgreSQL_PGXS_SRC_DIR "${PostgreSQL_PGXS_MAKEFILES_DIR}" DIRECTORY)
+  set(PostgreSQL_MAKEFILE_GLOBAL "${PostgreSQL_PGXS_SRC_DIR}/Makefile.global")
+  if(EXISTS "${PostgreSQL_MAKEFILE_GLOBAL}")
+    file(STRINGS "${PostgreSQL_MAKEFILE_GLOBAL}" PostgreSQL_COMPILE_C_BC_LINE
+      REGEX "^COMPILE\\.c\\.bc[ \t]*="
+    )
+    if(PostgreSQL_COMPILE_C_BC_LINE)
+      list(GET PostgreSQL_COMPILE_C_BC_LINE 0 PostgreSQL_COMPILE_C_BC_STRING)
+      string(REGEX REPLACE "^COMPILE\\.c\\.bc[ \t]*=[ \t]*(.*)[ \t]*$" "\\1"
+        PostgreSQL_COMPILE_C_BC_STRING "${PostgreSQL_COMPILE_C_BC_STRING}"
+      )
+      string(REPLACE "$(CLANG)" "" PostgreSQL_COMPILE_C_BC_STRING "${PostgreSQL_COMPILE_C_BC_STRING}")
+      string(REGEX REPLACE "\\$\\(BITCODE_CFLAGS\\).*$" ""
+        PostgreSQL_COMPILE_C_BC_STRING "${PostgreSQL_COMPILE_C_BC_STRING}"
+      )
+      separate_arguments(PostgreSQL_BITCODE_COMPILER_FLAGS UNIX_COMMAND "${PostgreSQL_COMPILE_C_BC_STRING}")
+    endif()
+    unset(PostgreSQL_COMPILE_C_BC_LINE)
+    unset(PostgreSQL_COMPILE_C_BC_STRING)
+
+    file(STRINGS "${PostgreSQL_MAKEFILE_GLOBAL}" PostgreSQL_BITCODE_CFLAGS_LINE
+      REGEX "^BITCODE_CFLAGS[ \t]*="
+    )
+    if(PostgreSQL_BITCODE_CFLAGS_LINE)
+      list(GET PostgreSQL_BITCODE_CFLAGS_LINE 0 PostgreSQL_BITCODE_CFLAGS_STRING)
+      string(REGEX REPLACE "^BITCODE_CFLAGS[ \t]*=[ \t]*(.*)[ \t]*$" "\\1"
+        PostgreSQL_BITCODE_CFLAGS_STRING "${PostgreSQL_BITCODE_CFLAGS_STRING}"
+      )
+      separate_arguments(PostgreSQL_BITCODE_CFLAGS UNIX_COMMAND "${PostgreSQL_BITCODE_CFLAGS_STRING}")
+    endif()
+    unset(PostgreSQL_BITCODE_CFLAGS_LINE)
+    unset(PostgreSQL_BITCODE_CFLAGS_STRING)
+  endif()
+endif()
+if(PostgreSQL_WITH_LLVM AND NOT PostgreSQL_BITCODE_CFLAGS)
+  set(PostgreSQL_BITCODE_CFLAGS "-O2")
+endif()
+if(PostgreSQL_WITH_LLVM AND NOT PostgreSQL_BITCODE_COMPILER_FLAGS)
+  set(PostgreSQL_BITCODE_COMPILER_FLAGS "-Wno-ignored-attributes")
+endif()
 
 # @TODO: Figure out if we need _INCLUDE_DIR and/or _PKG_INCLUDE_DIR
 

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -41,6 +41,9 @@ execute_process(COMMAND ${PostgreSQL_CONFIG} --configure         OUTPUT_VARIABLE
 execute_process(COMMAND ${PostgreSQL_CONFIG} --cppflags          OUTPUT_VARIABLE PostgreSQL_CPPFLAGS_STRING    OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND ${PostgreSQL_CONFIG} --pgxs              OUTPUT_VARIABLE PostgreSQL_PGXS               OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+if(PostgreSQL_CPPFLAGS_STRING STREQUAL "not recorded")
+  set(PostgreSQL_CPPFLAGS_STRING "")
+endif()
 separate_arguments(PostgreSQL_CPPFLAGS UNIX_COMMAND "${PostgreSQL_CPPFLAGS_STRING}")
 
 # PostgreSQL can optionally be built with LLVM support (`--with-llvm`).

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -23,6 +23,9 @@ These exist only in h3-pg, not other H3 language bindings.
 - `a <-> b` — grid distance in cells between two h3index values (`h3`)
 - `geom @ resolution` — index geometry/geography at resolution (`h3_postgis`)
 
+**Directed edge convenience** (`h3`):
+- `h3_reverse_directed_edge(edge)` — returns the same directed edge with origin and destination reversed
+
 **Operator classes** for `h3index`: BTREE, HASH, BRIN, SP-GIST (`h3`)
 
 **Boundary helpers** (`h3_postgis`):

--- a/docs/api.md
+++ b/docs/api.md
@@ -363,6 +363,13 @@ Returns all unidirectional edges with the given index as origin.
 Provides the coordinates defining the unidirectional edge.
 
 
+### h3_reverse_directed_edge(edge `h3index`) ⇒ `h3index`
+*Since vunreleased*
+
+
+Returns the directed edge with origin and destination cells reversed.
+
+
 # H3 Vertex functions
 Functions for working with cell vertexes.
 

--- a/h3/sql/install/06-edge.sql
+++ b/h3/sql/install/06-edge.sql
@@ -74,3 +74,10 @@ CREATE OR REPLACE FUNCTION
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
     h3_directed_edge_to_boundary(edge h3index)
 IS 'Provides the coordinates defining the unidirectional edge.';
+
+--@ availability: unreleased
+CREATE OR REPLACE FUNCTION
+    h3_reverse_directed_edge(edge h3index) RETURNS h3index
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
+    h3_reverse_directed_edge(edge h3index)
+IS 'Returns the directed edge with origin and destination cells reversed.';

--- a/h3/sql/updates/h3--4.2.3--unreleased.sql
+++ b/h3/sql/updates/h3--4.2.3--unreleased.sql
@@ -298,6 +298,13 @@ COMMENT ON FUNCTION
     h3_grid_distance(h3index, h3index)
 IS 'Returns the shortest grid distance between two cells. Raises an error when the cells are not comparable, too far apart, or the path crosses pentagonal distortion.';
 
+CREATE OR REPLACE FUNCTION
+    h3_reverse_directed_edge(edge h3index) RETURNS h3index
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION
+    h3_reverse_directed_edge(edge h3index)
+IS 'Returns the directed edge with origin and destination cells reversed.';
+
 COMMENT ON FUNCTION
     h3_cell_to_children(h3index, integer)
 IS 'Returns the ordered set of children of the given index at the target resolution.';

--- a/h3/src/binding/edge.c
+++ b/h3/src/binding/edge.c
@@ -39,6 +39,7 @@ PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_get_directed_edge_destination);
 PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_directed_edge_to_cells);
 PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_origin_to_directed_edges);
 PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_directed_edge_to_boundary);
+PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_reverse_directed_edge);
 
 /* Returns whether or not the provided H3 cell indexes are neighbors. */
 Datum
@@ -173,4 +174,16 @@ h3_directed_edge_to_boundary(PG_FUNCTION_ARGS)
 	}
 	h3_polygon_init_boundbox(polygon);
 	PG_RETURN_POLYGON_P(polygon);
+}
+
+/* Returns the directed edge with origin and destination cells reversed. */
+Datum
+h3_reverse_directed_edge(PG_FUNCTION_ARGS)
+{
+	H3Index		reversed;
+	H3Index		edge = PG_GETARG_H3INDEX(0);
+
+	h3_assert(reverseDirectedEdge(edge, &reversed));
+
+	PG_RETURN_H3INDEX(reversed);
 }

--- a/h3/src/binding/traversal.c
+++ b/h3/src/binding/traversal.c
@@ -20,6 +20,7 @@
 #include <fmgr.h>			 // PG_FUNCTION_ARGS
 #include <funcapi.h>		 // SRF_IS_FIRSTCALL
 #include <utils/geo_decls.h> // PG_GETARG_POINT_P
+#include <utils/memutils.h>
 
 #include "error.h"
 #include "type.h"
@@ -45,6 +46,16 @@ ensure_nonnegative_k(int k)
 		return 0;
 	}
 	return k;
+}
+
+static void *
+palloc_h3_array_checked(int64_t count, Size elementSize, bool zero)
+{
+	if (count < 0 || (uint64) count > MaxAllocSize / elementSize)
+		elog(ERROR, "too many grid traversal cells");
+	return zero
+		? palloc0((Size) count * elementSize)
+		: palloc((Size) count * elementSize);
 }
 
 /*
@@ -75,7 +86,7 @@ h3_grid_disk(PG_FUNCTION_ARGS)
 
 		h3_assert(maxGridDiskSize(k, &max));
 
-		indices = palloc0(max * sizeof(H3Index));
+		indices = palloc_h3_array_checked(max, sizeof(H3Index), true);
 
 		h3_assert(gridDisk(origin, k, indices));
 
@@ -123,8 +134,8 @@ h3_grid_disk_distances(PG_FUNCTION_ARGS)
 
 		user_fctx = palloc(sizeof(hexDistanceTuple));
 
-		user_fctx->indices = palloc0(maxSize * sizeof(H3Index));
-		user_fctx->distances = palloc0(maxSize * sizeof(int));
+		user_fctx->indices = palloc_h3_array_checked(maxSize, sizeof(H3Index), true);
+		user_fctx->distances = palloc_h3_array_checked(maxSize, sizeof(int), true);
 
 		h3_assert(gridDiskDistances(origin, k, user_fctx->indices, user_fctx->distances));
 
@@ -163,7 +174,7 @@ h3_grid_ring(PG_FUNCTION_ARGS)
 
 		h3_assert(maxGridRingSize(k, &maxSize));
 
-		indices = palloc0(maxSize * sizeof(H3Index));
+		indices = palloc_h3_array_checked(maxSize, sizeof(H3Index), true);
 
 		h3_assert(gridRing(origin, k, indices));
 
@@ -198,7 +209,7 @@ h3_grid_ring_unsafe(PG_FUNCTION_ARGS)
 		int64_t		maxSize;
 
 		h3_assert(maxGridRingSize(k, &maxSize));
-		indices = palloc(maxSize * sizeof(H3Index));
+		indices = palloc_h3_array_checked(maxSize, sizeof(H3Index), false);
 
 		h3_assert(gridRingUnsafe(origin, k, indices));
 
@@ -255,7 +266,7 @@ h3_grid_path_cells(PG_FUNCTION_ARGS)
 
 		h3_assert(gridPathCellsSize(start, end, &size));
 
-		indices = palloc(size * sizeof(H3Index));
+		indices = palloc_h3_array_checked(size, sizeof(H3Index), false);
 
 		h3_assert(gridPathCells(start, end, indices));
 

--- a/h3/src/binding/traversal.c
+++ b/h3/src/binding/traversal.c
@@ -51,7 +51,8 @@ ensure_nonnegative_k(int k)
 static void *
 palloc_h3_array_checked(int64_t count, Size elementSize, bool zero)
 {
-	if (count < 0 || (uint64) count > MaxAllocSize / elementSize)
+	if (elementSize == 0 || count < 0 ||
+		(uint64) count > MaxAllocSize / elementSize)
 		elog(ERROR, "too many grid traversal cells");
 	return zero
 		? palloc0((Size) count * elementSize)

--- a/h3/test/expected/edge.out
+++ b/h3/test/expected/edge.out
@@ -67,3 +67,25 @@ SELECT box(h3_directed_edge_to_boundary(:edge))
 ;
  t
 
+--
+-- TEST h3_reverse_directed_edge
+--
+SELECT h3_directed_edge_to_cells(h3_reverse_directed_edge(:edge)) = (:neighbor, :hexagon);
+ t
+
+SELECT h3_reverse_directed_edge(h3_reverse_directed_edge(:edge)) = :edge;
+ t
+
+CREATE FUNCTION h3_test_reverse_directed_edge_invalid() RETURNS boolean LANGUAGE PLPGSQL
+    AS $$
+        BEGIN
+            PERFORM h3_reverse_directed_edge('880326b885fffff'::h3index);
+            RETURN false;
+        EXCEPTION WHEN OTHERS THEN
+            RETURN true;
+        END;
+    $$;
+SELECT h3_test_reverse_directed_edge_invalid();
+ t
+
+DROP FUNCTION h3_test_reverse_directed_edge_invalid;

--- a/h3/test/expected/extension.out
+++ b/h3/test/expected/extension.out
@@ -127,6 +127,10 @@ SELECT bool_and(h3_is_valid_index(r)) AND COUNT(*) = 6
 FROM h3_grid_ring('831c02fffffffff'::h3index, 1) AS r;
  t
 
+SELECT h3_directed_edge_to_cells(h3_reverse_directed_edge('1180326b885fffff'::h3index))
+    = ('880326b887fffff'::h3index, '880326b885fffff'::h3index);
+ t
+
 SELECT op_dist = 1 AND fn_dist = 1 FROM h3_distance_view;
  t
 

--- a/h3/test/expected/regions.out
+++ b/h3/test/expected/regions.out
@@ -38,6 +38,21 @@ SELECT COUNT(*) = 0
 FROM h3_cells_to_multi_polygon(ARRAY[NULL::h3index]);
  t
 
+-- H3 v4.5.0 rejects ambiguous duplicate-cell outlines instead of producing
+-- undefined polygon output.
+CREATE FUNCTION h3_test_cells_to_multi_polygon_duplicate() RETURNS boolean LANGUAGE PLPGSQL
+    AS $$
+        BEGIN
+            PERFORM h3_cells_to_multi_polygon(ARRAY['831c02fffffffff'::h3index, '831c02fffffffff'::h3index]);
+            RETURN false;
+        EXCEPTION WHEN OTHERS THEN
+            RETURN true;
+        END;
+    $$;
+SELECT h3_test_cells_to_multi_polygon_duplicate();
+ t
+
+DROP FUNCTION h3_test_cells_to_multi_polygon_duplicate;
 -- h3_polygon_to_cells is inverse of h3_cells_to_multi_polygon for set with a hole
 SELECT array_agg(result) is null FROM (
     SELECT h3_polygon_to_cells(exterior, holes, 1) result FROM (

--- a/h3/test/expected/traversal.out
+++ b/h3/test/expected/traversal.out
@@ -119,6 +119,12 @@ SELECT ARRAY(SELECT h3_grid_path_cells('841c023ffffffff', '841c025ffffffff'))
     = ARRAY['841c023ffffffff','841c027ffffffff','841c025ffffffff']::h3index[];
  t
 
+-- H3 v4.5.0 can find paths in both directions for cases that previously only
+-- worked from one side.
+SELECT ARRAY(SELECT h3_grid_path_cells('841c025ffffffff', '841c023ffffffff'))
+    = ARRAY['841c025ffffffff','841c027ffffffff','841c023ffffffff']::h3index[];
+ t
+
 --
 -- TEST h3_grid_distance
 --

--- a/h3/test/sql/edge.sql
+++ b/h3/test/sql/edge.sql
@@ -60,3 +60,22 @@ SELECT h3_directed_edge_to_boundary(:edge)
 SELECT box(h3_directed_edge_to_boundary(:edge))
 	~= box '(89.58301649465479,64.7146398954916),(89.57906780217422,64.28722315172165)'
 ;
+
+--
+-- TEST h3_reverse_directed_edge
+--
+
+SELECT h3_directed_edge_to_cells(h3_reverse_directed_edge(:edge)) = (:neighbor, :hexagon);
+SELECT h3_reverse_directed_edge(h3_reverse_directed_edge(:edge)) = :edge;
+
+CREATE FUNCTION h3_test_reverse_directed_edge_invalid() RETURNS boolean LANGUAGE PLPGSQL
+    AS $$
+        BEGIN
+            PERFORM h3_reverse_directed_edge('880326b885fffff'::h3index);
+            RETURN false;
+        EXCEPTION WHEN OTHERS THEN
+            RETURN true;
+        END;
+    $$;
+SELECT h3_test_reverse_directed_edge_invalid();
+DROP FUNCTION h3_test_reverse_directed_edge_invalid;

--- a/h3/test/sql/extension.sql
+++ b/h3/test/sql/extension.sql
@@ -142,6 +142,9 @@ SELECT '831c02fffffffff'::h3index = h3_construct_cell(
 SELECT bool_and(h3_is_valid_index(r)) AND COUNT(*) = 6
 FROM h3_grid_ring('831c02fffffffff'::h3index, 1) AS r;
 
+SELECT h3_directed_edge_to_cells(h3_reverse_directed_edge('1180326b885fffff'::h3index))
+    = ('880326b887fffff'::h3index, '880326b885fffff'::h3index);
+
 SELECT op_dist = 1 AND fn_dist = 1 FROM h3_distance_view;
 
 DROP VIEW h3_distance_view;

--- a/h3/test/sql/regions.sql
+++ b/h3/test/sql/regions.sql
@@ -36,6 +36,20 @@ FROM h3_cells_to_multi_polygon(ARRAY[:hexagon, NULL::h3index]);
 SELECT COUNT(*) = 0
 FROM h3_cells_to_multi_polygon(ARRAY[NULL::h3index]);
 
+-- H3 v4.5.0 rejects ambiguous duplicate-cell outlines instead of producing
+-- undefined polygon output.
+CREATE FUNCTION h3_test_cells_to_multi_polygon_duplicate() RETURNS boolean LANGUAGE PLPGSQL
+    AS $$
+        BEGIN
+            PERFORM h3_cells_to_multi_polygon(ARRAY['831c02fffffffff'::h3index, '831c02fffffffff'::h3index]);
+            RETURN false;
+        EXCEPTION WHEN OTHERS THEN
+            RETURN true;
+        END;
+    $$;
+SELECT h3_test_cells_to_multi_polygon_duplicate();
+DROP FUNCTION h3_test_cells_to_multi_polygon_duplicate;
+
 -- h3_polygon_to_cells is inverse of h3_cells_to_multi_polygon for set with a hole
 SELECT array_agg(result) is null FROM (
     SELECT h3_polygon_to_cells(exterior, holes, 1) result FROM (

--- a/h3/test/sql/traversal.sql
+++ b/h3/test/sql/traversal.sql
@@ -115,6 +115,11 @@ FROM h3_grid_disk_distances(:pentagon, 2);
 SELECT ARRAY(SELECT h3_grid_path_cells('841c023ffffffff', '841c025ffffffff'))
     = ARRAY['841c023ffffffff','841c027ffffffff','841c025ffffffff']::h3index[];
 
+-- H3 v4.5.0 can find paths in both directions for cases that previously only
+-- worked from one side.
+SELECT ARRAY(SELECT h3_grid_path_cells('841c025ffffffff', '841c023ffffffff'))
+    = ARRAY['841c025ffffffff','841c027ffffffff','841c023ffffffff']::h3index[];
+
 --
 -- TEST h3_grid_distance
 --

--- a/h3_postgis/CMakeLists.txt
+++ b/h3_postgis/CMakeLists.txt
@@ -10,6 +10,7 @@ PostgreSQL_add_extension(postgresql_h3_postgis
     postgis_raster
   SOURCES
     src/init.c
+    src/wkb_vertex_graph.c
     src/wkb_bbox3.c
     src/wkb_indexing.c
     src/wkb_linked_geo.c

--- a/h3_postgis/src/wkb_regions.c
+++ b/h3_postgis/src/wkb_regions.c
@@ -23,10 +23,10 @@
 #include <linkedGeo.h>
 #include <math.h>
 #include <utils/array.h> // using arrays
-#include <vertexGraph.h>
 
 #include "error.h"
 #include "type.h"
+#include "wkb_vertex_graph.h"
 #include "wkb_linked_geo.h"
 #include "wkb_split.h"
 #include "wkb.h"

--- a/h3_postgis/src/wkb_regions.c
+++ b/h3_postgis/src/wkb_regions.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <limits.h>
+
 #include <postgres.h>
 #include <h3api.h>
 
@@ -227,6 +229,9 @@ static void
 
 static int
 			count_linked_polygon_edges(const LinkedGeoPolygon * multiPolygon);
+
+static int
+			vertex_graph_bucket_count(int edgeCount);
 
 static void
 			collect_linked_polygon_segments(const LinkedGeoPolygon * multiPolygon, NodedSegment * segments, int segmentCount);
@@ -1621,6 +1626,8 @@ count_linked_polygon_edges(const LinkedGeoPolygon * multiPolygon)
 
 			do
 			{
+				if (count == INT_MAX)
+					elog(ERROR, "too many polygon edges");
 				count++;
 				cur = cur->next ? cur->next : first;
 			}
@@ -1629,6 +1636,18 @@ count_linked_polygon_edges(const LinkedGeoPolygon * multiPolygon)
 	}
 
 	return count;
+}
+
+static int
+vertex_graph_bucket_count(int edgeCount)
+{
+	if (edgeCount <= 0)
+		return 1;
+
+	if (edgeCount > INT_MAX / 2)
+		elog(ERROR, "too many polygon edges");
+
+	return edgeCount * 2;
 }
 
 /* Materialize all split-boundary edges into noded segments with split markers. */
@@ -1927,7 +1946,7 @@ polygonize_noded_linked_polygon(const LinkedGeoPolygon * multiPolygon, int resol
 
 	initVertexGraph(
 		&graph,
-		edgeCount * edgeCount,
+		vertex_graph_bucket_count(edgeCount),
 		resolution >= 0 ? resolution : 0);
 	graph_add_noded_linked_polygon_edges(&graph, multiPolygon);
 	result = polygonize_noded_graph(&graph);

--- a/h3_postgis/src/wkb_regions.c
+++ b/h3_postgis/src/wkb_regions.c
@@ -23,8 +23,10 @@
 #include <float.h>
 #include <fmgr.h>		 // PG_FUNCTION_ARGS
 #include <linkedGeo.h>
+#include <miscadmin.h>
 #include <math.h>
 #include <utils/array.h> // using arrays
+#include <utils/memutils.h>
 
 #include "error.h"
 #include "type.h"
@@ -233,6 +235,15 @@ static int
 static int
 			vertex_graph_bucket_count(int edgeCount);
 
+static void *
+			palloc_array_checked(Size count, Size elementSize);
+
+static void *
+			palloc0_array_checked(Size count, Size elementSize);
+
+static void *
+			repalloc_array_checked(void *pointer, Size count, Size elementSize);
+
 static void
 			collect_linked_polygon_segments(const LinkedGeoPolygon * multiPolygon, NodedSegment * segments, int segmentCount);
 
@@ -312,7 +323,7 @@ h3_cells_to_multi_polygon_wkb(PG_FUNCTION_ARGS)
 	bool		localLinkedPolygon = false;
 
 	numHexes = ArrayGetNItems(ARR_NDIM(array), ARR_DIMS(array));
-	h3set = palloc(numHexes * sizeof(*h3set));
+	h3set = palloc_array_checked(numHexes, sizeof(*h3set));
 
 	/* Extract data from array into h3set */
 	iterator = array_create_iterator(array, 0, NULL);
@@ -599,8 +610,8 @@ cell_set_is_full_globe(const H3Index * h3set, int numHexes)
 	}
 
 	h3_assert(H3_EXPORT(getNumCells)(0, &numRes0));
-	compacted = palloc0(numHexes * sizeof(*compacted));
-	res0 = palloc(numRes0 * sizeof(*res0));
+	compacted = palloc0_array_checked(numHexes, sizeof(*compacted));
+	res0 = palloc_array_checked(numRes0, sizeof(*res0));
 
 	/*
 	 * "Full globe" here means "compacts exactly to the canonical res0 globe",
@@ -851,13 +862,13 @@ normalize_split_linked_polygon(const LinkedGeoPolygon * multiPolygon)
 	flattened = (LinkedGeoPolygon) {0};
 	collect_unique_split_loops(&flattened, multiPolygon);
 	loopCount = count_linked_geo_loops(&flattened);
-	loops = palloc(loopCount * sizeof(*loops));
-	bounds = palloc(loopCount * sizeof(*bounds));
-	probes = palloc(loopCount * sizeof(*probes));
-	areas = palloc(loopCount * sizeof(*areas));
-	parents = palloc(loopCount * sizeof(*parents));
-	depths = palloc(loopCount * sizeof(*depths));
-	polygons = palloc0(loopCount * sizeof(*polygons));
+	loops = palloc_array_checked(loopCount, sizeof(*loops));
+	bounds = palloc_array_checked(loopCount, sizeof(*bounds));
+	probes = palloc_array_checked(loopCount, sizeof(*probes));
+	areas = palloc_array_checked(loopCount, sizeof(*areas));
+	parents = palloc_array_checked(loopCount, sizeof(*parents));
+	depths = palloc_array_checked(loopCount, sizeof(*depths));
+	polygons = palloc0_array_checked(loopCount, sizeof(*polygons));
 
 	{
 		int			loopIdx = 0;
@@ -1052,7 +1063,7 @@ copy_linked_geo_loop_vertices(const LinkedGeoLoop * loop, LatLng ** verts)
 	int	count = count_linked_lat_lng(loop);
 	int	idx = 0;
 
-	*verts = palloc(count * sizeof(**verts));
+	*verts = palloc_array_checked(count, sizeof(**verts));
 	FOREACH_LINKED_LAT_LNG(loop, latlng)
 		(*verts)[idx++] = latlng->vertex;
 
@@ -1301,8 +1312,8 @@ split_self_touching_polygons(const LinkedGeoPolygon * multiPolygon)
 			if (vertCount < 3)
 				continue;
 
-			verts = palloc(vertCount * sizeof(*verts));
-			stack = palloc(vertCount * sizeof(*stack));
+			verts = palloc_array_checked(vertCount, sizeof(*verts));
+			stack = palloc_array_checked(vertCount, sizeof(*stack));
 			FOREACH_LINKED_LAT_LNG(loop, latlng)
 				verts[idx++] = latlng->vertex;
 
@@ -1396,10 +1407,10 @@ loop_probe_point(const LinkedGeoLoop * loop, const LoopBounds * bounds)
 {
 	LatLng		probe = {0};
 	int			vertexCount = count_linked_lat_lng(loop);
-	double	   *lats = palloc(vertexCount * sizeof(*lats));
-	double	   *ringLats = palloc(vertexCount * sizeof(*ringLats));
-	double	   *lngs = palloc(vertexCount * sizeof(*lngs));
-	double	   *xs = palloc(vertexCount * sizeof(*xs));
+	double	   *lats = palloc_array_checked(vertexCount, sizeof(*lats));
+	double	   *ringLats = palloc_array_checked(vertexCount, sizeof(*ringLats));
+	double	   *lngs = palloc_array_checked(vertexCount, sizeof(*lngs));
+	double	   *xs = palloc_array_checked(vertexCount, sizeof(*xs));
 	int			latCount = 0;
 	double		bestWidth = -1.0;
 	double		minLng = 0.0;
@@ -1650,6 +1661,30 @@ vertex_graph_bucket_count(int edgeCount)
 	return edgeCount * 2;
 }
 
+static void *
+palloc_array_checked(Size count, Size elementSize)
+{
+	if (elementSize != 0 && count > MaxAllocSize / elementSize)
+		elog(ERROR, "too many polygon edges");
+	return palloc(count * elementSize);
+}
+
+static void *
+palloc0_array_checked(Size count, Size elementSize)
+{
+	if (elementSize != 0 && count > MaxAllocSize / elementSize)
+		elog(ERROR, "too many polygon edges");
+	return palloc0(count * elementSize);
+}
+
+static void *
+repalloc_array_checked(void *pointer, Size count, Size elementSize)
+{
+	if (elementSize != 0 && count > MaxAllocSize / elementSize)
+		elog(ERROR, "too many polygon edges");
+	return repalloc(pointer, count * elementSize);
+}
+
 /* Materialize all split-boundary edges into noded segments with split markers. */
 void
 collect_linked_polygon_segments(const LinkedGeoPolygon * multiPolygon, NodedSegment * segments, int segmentCount)
@@ -1669,7 +1704,11 @@ collect_linked_polygon_segments(const LinkedGeoPolygon * multiPolygon, NodedSegm
 			do
 			{
 				const LinkedLatLng *next = cur->next ? cur->next : first;
-				NodedSegment *segment = &segments[idx++];
+				NodedSegment *segment;
+
+				if (idx >= segmentCount)
+					elog(ERROR, "too many polygon edges");
+				segment = &segments[idx++];
 
 				segment->from = cur->vertex;
 				segment->to = next->vertex;
@@ -1677,9 +1716,11 @@ collect_linked_polygon_segments(const LinkedGeoPolygon * multiPolygon, NodedSegm
 				segment->maxLat = fmax(segment->from.lat, segment->to.lat);
 				segment->minLng = fmin(segment->from.lng, segment->to.lng);
 				segment->maxLng = fmax(segment->from.lng, segment->to.lng);
-				segment->splitCap = segmentCount + 2;
+				segment->splitCap = 4;
 				segment->splitCount = 0;
-				segment->splitTs = palloc(segment->splitCap * sizeof(*segment->splitTs));
+				segment->splitTs = palloc_array_checked(
+					segment->splitCap,
+					sizeof(*segment->splitTs));
 				segment_add_split_t(segment, 0.0);
 				segment_add_split_t(segment, 1.0);
 
@@ -1706,10 +1747,15 @@ segment_add_split_t(NodedSegment * segment, double t)
 
 	if (segment->splitCount >= segment->splitCap)
 	{
+		if (segment->splitCap > INT_MAX / 2)
+			elog(ERROR, "too many polygon edges");
 		segment->splitCap = segment->splitCap > 0
 			? segment->splitCap * 2
 			: 4;
-		segment->splitTs = repalloc(segment->splitTs, segment->splitCap * sizeof(*segment->splitTs));
+		segment->splitTs = repalloc_array_checked(
+			segment->splitTs,
+			segment->splitCap,
+			sizeof(*segment->splitTs));
 	}
 
 	segment->splitTs[segment->splitCount++] = t;
@@ -1858,11 +1904,12 @@ graph_add_noded_linked_polygon_edges(VertexGraph * graph, const LinkedGeoPolygon
 	if (segmentCount <= 0)
 		return;
 
-	segments = palloc(segmentCount * sizeof(*segments));
+	segments = palloc_array_checked(segmentCount, sizeof(*segments));
 	collect_linked_polygon_segments(multiPolygon, segments, segmentCount);
 
 	for (int i = 0; i < segmentCount; i++)
 	{
+		CHECK_FOR_INTERRUPTS();
 		for (int j = i + 1; j < segmentCount; j++)
 		{
 			double		ti;
@@ -1871,6 +1918,9 @@ graph_add_noded_linked_polygon_edges(VertexGraph * graph, const LinkedGeoPolygon
 			double		overlapEndI;
 			double		overlapStartJ;
 			double		overlapEndJ;
+
+			if ((j & 0x3ff) == 0)
+				CHECK_FOR_INTERRUPTS();
 
 			if (!segments_bounds_overlap(&segments[i], &segments[j]))
 				continue;
@@ -1899,6 +1949,7 @@ graph_add_noded_linked_polygon_edges(VertexGraph * graph, const LinkedGeoPolygon
 	{
 		NodedSegment *segment = &segments[i];
 
+		CHECK_FOR_INTERRUPTS();
 		qsort(segment->splitTs, segment->splitCount, sizeof(*segment->splitTs), double_cmp);
 		for (int j = 0; j + 1 < segment->splitCount; j++)
 		{
@@ -1928,7 +1979,10 @@ graph_add_edge(VertexGraph * graph, const LatLng * from, const LatLng * to)
 	VertexNode *reverse = findNodeForEdge(graph, to, from);
 
 	if (reverse)
-		removeVertexNode(graph, reverse);
+	{
+		if (removeVertexNode(graph, reverse) != 0)
+			elog(ERROR, "vertex graph edge disappeared during removal");
+	}
 	else
 		addVertexNode(graph, from, to);
 }
@@ -1965,7 +2019,7 @@ polygonize_noded_graph(const VertexGraph * graph)
 	int			vertexCount = 0;
 	int			vertexCap = 0;
 	int			edgeIdx = 0;
-	int			halfEdgeCount = graph->size * 2;
+	int			halfEdgeCount;
 	LinkedGeoPolygon *raw = NULL;
 	LinkedGeoPolygon *lastPolygon = NULL;
 	LinkedGeoPolygon *result;
@@ -1973,9 +2027,14 @@ polygonize_noded_graph(const VertexGraph * graph)
 	if (graph->size == 0)
 		return palloc0(sizeof(*result));
 
-	edges = palloc0(halfEdgeCount * sizeof(*edges));
+	if (graph->size > INT_MAX / 2)
+		elog(ERROR, "too many polygon edges");
+	halfEdgeCount = graph->size * 2;
+
+	edges = palloc0_array_checked(halfEdgeCount, sizeof(*edges));
 	for (int bucketIdx = 0; bucketIdx < graph->numBuckets; bucketIdx++)
 	{
+		CHECK_FOR_INTERRUPTS();
 		for (VertexNode *node = graph->buckets[bucketIdx]; node; node = node->next)
 		{
 			double		dLng = normalize_lng_around(node->to.lng, node->from.lng) - node->from.lng;
@@ -1983,6 +2042,9 @@ polygonize_noded_graph(const VertexGraph * graph)
 				&vertices, &vertexCount, &vertexCap, &node->from);
 			int			toVertex = polygonize_find_or_add_vertex(
 				&vertices, &vertexCount, &vertexCap, &node->to);
+
+			if (edgeIdx > halfEdgeCount - 2)
+				elog(ERROR, "too many polygon edges");
 
 			edges[edgeIdx].from = node->from;
 			edges[edgeIdx].to = node->to;
@@ -2004,13 +2066,17 @@ polygonize_noded_graph(const VertexGraph * graph)
 		}
 	}
 
-	edgeRefs = palloc(edgeIdx * sizeof(*edgeRefs));
-	edgeOffsets = palloc(vertexCount * sizeof(*edgeOffsets));
+	if (edgeIdx != halfEdgeCount)
+		elog(ERROR, "vertex graph edge count changed during polygonization");
+
+	edgeRefs = palloc_array_checked(edgeIdx, sizeof(*edgeRefs));
+	edgeOffsets = palloc_array_checked(vertexCount, sizeof(*edgeOffsets));
 	{
 		int			offset = 0;
 
 		for (int i = 0; i < vertexCount; i++)
 		{
+			CHECK_FOR_INTERRUPTS();
 			vertices[i].firstEdge = offset;
 			edgeOffsets[i] = offset;
 			offset += vertices[i].edgeCount;
@@ -2020,11 +2086,15 @@ polygonize_noded_graph(const VertexGraph * graph)
 	{
 		int			offset = edgeOffsets[edges[i].fromVertex]++;
 
+		if ((i & 0x3ff) == 0)
+			CHECK_FOR_INTERRUPTS();
+
 		edgeRefs[offset].edgeIdx = i;
 		edgeRefs[offset].angle = edges[i].angle;
 	}
 	for (int i = 0; i < vertexCount; i++)
 	{
+		CHECK_FOR_INTERRUPTS();
 		if (vertices[i].edgeCount > 1)
 		{
 			qsort(
@@ -2041,6 +2111,9 @@ polygonize_noded_graph(const VertexGraph * graph)
 		double		reverseAngle = edges[i].angle + M_PI;
 		double		bestDelta = DBL_MAX;
 		int			bestEdge = -1;
+
+		if ((i & 0x3ff) == 0)
+			CHECK_FOR_INTERRUPTS();
 
 		while (reverseAngle > M_PI)
 			reverseAngle -= 2.0 * M_PI;
@@ -2070,6 +2143,9 @@ polygonize_noded_graph(const VertexGraph * graph)
 		int			cur = i;
 		int			guard = 0;
 
+		if ((i & 0x3ff) == 0)
+			CHECK_FOR_INTERRUPTS();
+
 		if (edges[i].used || edges[i].nextEdge < 0)
 			continue;
 
@@ -2079,6 +2155,8 @@ polygonize_noded_graph(const VertexGraph * graph)
 
 		while (cur >= 0 && !edges[cur].used && guard++ <= edgeIdx)
 		{
+			if ((guard & 0x3ff) == 0)
+				CHECK_FOR_INTERRUPTS();
 			if (!loop->last || !geoAlmostEqual(&loop->last->vertex, &edges[cur].from))
 			{
 				LinkedLatLng *latlng = palloc0(sizeof(*latlng));
@@ -2138,10 +2216,12 @@ polygonize_find_or_add_vertex(PolygonizeVertex **vertices, int *vertexCount, int
 
 	if (*vertexCount >= *vertexCap)
 	{
+		if (*vertexCap > INT_MAX / 2)
+			elog(ERROR, "too many polygon edges");
 		*vertexCap = *vertexCap ? *vertexCap * 2 : 32;
 		*vertices = *vertices
-			? repalloc(*vertices, *vertexCap * sizeof(**vertices))
-			: palloc(*vertexCap * sizeof(**vertices));
+			? repalloc_array_checked(*vertices, *vertexCap, sizeof(**vertices))
+			: palloc_array_checked(*vertexCap, sizeof(**vertices));
 	}
 
 	(*vertices)[*vertexCount] = (PolygonizeVertex) {
@@ -2433,7 +2513,7 @@ prune_linked_geo_loop_spikes(LinkedGeoLoop * loop)
 		return;
 	}
 
-	stack = palloc(count * sizeof(*stack));
+	stack = palloc_array_checked(count, sizeof(*stack));
 
 	for (int i = 0; i < count; i++)
 	{

--- a/h3_postgis/src/wkb_vertex_graph.c
+++ b/h3_postgis/src/wkb_vertex_graph.c
@@ -21,30 +21,42 @@
 
 #include "wkb_vertex_graph.h"
 
-static uint32_t hash_vertex(const LatLng *vertex, int res, int numBuckets);
-static VertexNode *first_vertex_node(const VertexGraph *graph);
+static uint32_t hash_vertex(const VertexGraph *graph, const LatLng *vertex);
 
 void
 initVertexGraph(VertexGraph *graph, int numBuckets, int res)
 {
-	graph->buckets = numBuckets > 0
-		? palloc0(numBuckets * sizeof(VertexNode *))
-		: NULL;
+	if (numBuckets <= 0)
+		numBuckets = 1;
+
+	graph->buckets = palloc0(numBuckets * sizeof(VertexNode *));
 	graph->numBuckets = numBuckets;
 	graph->size = 0;
 	graph->res = res;
+	graph->resMultiplier = pow(10.0, 15 - res);
 }
 
 void
 destroyVertexGraph(VertexGraph *graph)
 {
-	VertexNode *node;
+	for (int i = 0; i < graph->numBuckets; i++)
+	{
+		VertexNode *node = graph->buckets[i];
 
-	while ((node = first_vertex_node(graph)) != NULL)
-		removeVertexNode(graph, node);
+		while (node != NULL)
+		{
+			VertexNode *next = node->next;
+
+			pfree(node);
+			node = next;
+		}
+	}
 
 	if (graph->buckets)
 		pfree(graph->buckets);
+	graph->buckets = NULL;
+	graph->size = 0;
+	graph->numBuckets = 0;
 }
 
 VertexNode *
@@ -52,7 +64,7 @@ addVertexNode(VertexGraph *graph, const LatLng *fromVtx, const LatLng *toVtx)
 {
 	VertexNode *node;
 	VertexNode *currentNode;
-	uint32_t	index = hash_vertex(fromVtx, graph->res, graph->numBuckets);
+	uint32_t	index = hash_vertex(graph, fromVtx);
 
 	node = palloc(sizeof(*node));
 	node->from = *fromVtx;
@@ -88,7 +100,7 @@ addVertexNode(VertexGraph *graph, const LatLng *fromVtx, const LatLng *toVtx)
 int
 removeVertexNode(VertexGraph *graph, VertexNode *node)
 {
-	uint32_t	index = hash_vertex(&node->from, graph->res, graph->numBuckets);
+	uint32_t	index = hash_vertex(graph, &node->from);
 	VertexNode *currentNode = graph->buckets[index];
 	bool		found = false;
 
@@ -105,6 +117,7 @@ removeVertexNode(VertexGraph *graph, VertexNode *node)
 			{
 				currentNode->next = node->next;
 				found = true;
+				break;
 			}
 			currentNode = currentNode->next;
 		}
@@ -122,7 +135,7 @@ VertexNode *
 findNodeForEdge(const VertexGraph *graph, const LatLng *fromVtx,
 				const LatLng *toVtx)
 {
-	uint32_t	index = hash_vertex(fromVtx, graph->res, graph->numBuckets);
+	uint32_t	index = hash_vertex(graph, fromVtx);
 	VertexNode *node = graph->buckets[index];
 
 	while (node != NULL)
@@ -137,21 +150,11 @@ findNodeForEdge(const VertexGraph *graph, const LatLng *fromVtx,
 }
 
 static uint32_t
-hash_vertex(const LatLng *vertex, int res, int numBuckets)
+hash_vertex(const VertexGraph *graph, const LatLng *vertex)
 {
-	if (numBuckets <= 0)
+	if (graph->numBuckets <= 0)
 		return 0;
 
-	return (uint32_t) fmod(fabs((vertex->lat + vertex->lng) * pow(10, 15 - res)),
-						   numBuckets);
-}
-
-static VertexNode *
-first_vertex_node(const VertexGraph *graph)
-{
-	for (int i = 0; i < graph->numBuckets; i++)
-		if (graph->buckets[i] != NULL)
-			return graph->buckets[i];
-
-	return NULL;
+	return (uint32_t) fmod(fabs((vertex->lat + vertex->lng) * graph->resMultiplier),
+						   graph->numBuckets);
 }

--- a/h3_postgis/src/wkb_vertex_graph.c
+++ b/h3_postgis/src/wkb_vertex_graph.c
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017-2018, 2020-2021 Uber Technologies, Inc.
+ * Copyright 2026 Darafei Praliaskouski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <postgres.h>
+
+#include <math.h>
+
+#include "wkb_vertex_graph.h"
+
+static uint32_t hash_vertex(const LatLng *vertex, int res, int numBuckets);
+static VertexNode *first_vertex_node(const VertexGraph *graph);
+
+void
+initVertexGraph(VertexGraph *graph, int numBuckets, int res)
+{
+	graph->buckets = numBuckets > 0
+		? palloc0(numBuckets * sizeof(VertexNode *))
+		: NULL;
+	graph->numBuckets = numBuckets;
+	graph->size = 0;
+	graph->res = res;
+}
+
+void
+destroyVertexGraph(VertexGraph *graph)
+{
+	VertexNode *node;
+
+	while ((node = first_vertex_node(graph)) != NULL)
+		removeVertexNode(graph, node);
+
+	if (graph->buckets)
+		pfree(graph->buckets);
+}
+
+VertexNode *
+addVertexNode(VertexGraph *graph, const LatLng *fromVtx, const LatLng *toVtx)
+{
+	VertexNode *node;
+	VertexNode *currentNode;
+	uint32_t	index = hash_vertex(fromVtx, graph->res, graph->numBuckets);
+
+	node = palloc(sizeof(*node));
+	node->from = *fromVtx;
+	node->to = *toVtx;
+	node->next = NULL;
+
+	currentNode = graph->buckets[index];
+	if (currentNode == NULL)
+	{
+		graph->buckets[index] = node;
+	}
+	else
+	{
+		for (;;)
+		{
+			if (geoAlmostEqual(&currentNode->from, fromVtx) &&
+				geoAlmostEqual(&currentNode->to, toVtx))
+			{
+				pfree(node);
+				return currentNode;
+			}
+			if (currentNode->next == NULL)
+				break;
+			currentNode = currentNode->next;
+		}
+		currentNode->next = node;
+	}
+
+	graph->size++;
+	return node;
+}
+
+int
+removeVertexNode(VertexGraph *graph, VertexNode *node)
+{
+	uint32_t	index = hash_vertex(&node->from, graph->res, graph->numBuckets);
+	VertexNode *currentNode = graph->buckets[index];
+	bool		found = false;
+
+	if (currentNode != NULL)
+	{
+		if (currentNode == node)
+		{
+			graph->buckets[index] = node->next;
+			found = true;
+		}
+		while (!found && currentNode->next != NULL)
+		{
+			if (currentNode->next == node)
+			{
+				currentNode->next = node->next;
+				found = true;
+			}
+			currentNode = currentNode->next;
+		}
+	}
+
+	if (!found)
+		return 1;
+
+	pfree(node);
+	graph->size--;
+	return 0;
+}
+
+VertexNode *
+findNodeForEdge(const VertexGraph *graph, const LatLng *fromVtx,
+				const LatLng *toVtx)
+{
+	uint32_t	index = hash_vertex(fromVtx, graph->res, graph->numBuckets);
+	VertexNode *node = graph->buckets[index];
+
+	while (node != NULL)
+	{
+		if (geoAlmostEqual(&node->from, fromVtx) &&
+			(toVtx == NULL || geoAlmostEqual(&node->to, toVtx)))
+			return node;
+		node = node->next;
+	}
+
+	return NULL;
+}
+
+static uint32_t
+hash_vertex(const LatLng *vertex, int res, int numBuckets)
+{
+	if (numBuckets <= 0)
+		return 0;
+
+	return (uint32_t) fmod(fabs((vertex->lat + vertex->lng) * pow(10, 15 - res)),
+						   numBuckets);
+}
+
+static VertexNode *
+first_vertex_node(const VertexGraph *graph)
+{
+	for (int i = 0; i < graph->numBuckets; i++)
+		if (graph->buckets[i] != NULL)
+			return graph->buckets[i];
+
+	return NULL;
+}

--- a/h3_postgis/src/wkb_vertex_graph.c
+++ b/h3_postgis/src/wkb_vertex_graph.c
@@ -21,6 +21,16 @@
 
 #include "wkb_vertex_graph.h"
 
+/*
+ * This is a narrow replacement for H3's removed internal vertexGraph helper.
+ * h3_postgis uses it only while rebuilding WKB polygons from H3 cell
+ * boundaries that were split/noded for antimeridian and overlap handling.
+ *
+ * The graph stores directed boundary pieces. When the caller sees the same
+ * segment in the opposite direction, it removes the existing edge instead of
+ * adding another one; shared internal boundaries then disappear and only the
+ * exterior polygon rings remain for polygonize_noded_graph().
+ */
 static uint32_t hash_vertex(const VertexGraph *graph, const LatLng *vertex);
 
 void
@@ -29,16 +39,27 @@ initVertexGraph(VertexGraph *graph, int numBuckets, int res)
 	if (numBuckets <= 0)
 		numBuckets = 1;
 
+	/*
+	 * Keep buckets always allocated. The graph helpers index directly into this
+	 * array, so a zero-bucket graph would turn later add/find calls into NULL
+	 * dereferences.
+	 */
 	graph->buckets = palloc0(numBuckets * sizeof(VertexNode *));
 	graph->numBuckets = numBuckets;
 	graph->size = 0;
 	graph->res = res;
+	/*
+	 * Coordinates are compared with geoAlmostEqual(). The hash only needs to
+	 * group nearby starts well enough to avoid scanning every edge; exact graph
+	 * identity is still checked with geoAlmostEqual() on both endpoints.
+	 */
 	graph->resMultiplier = pow(10.0, 15 - res);
 }
 
 void
 destroyVertexGraph(VertexGraph *graph)
 {
+	/* Nodes are owned by their bucket chains, so free each chain directly. */
 	for (int i = 0; i < graph->numBuckets; i++)
 	{
 		VertexNode *node = graph->buckets[i];
@@ -80,6 +101,7 @@ addVertexNode(VertexGraph *graph, const LatLng *fromVtx, const LatLng *toVtx)
 	{
 		for (;;)
 		{
+			/* Avoid inserting the same directed boundary piece twice. */
 			if (geoAlmostEqual(&currentNode->from, fromVtx) &&
 				geoAlmostEqual(&currentNode->to, toVtx))
 			{
@@ -140,6 +162,11 @@ findNodeForEdge(const VertexGraph *graph, const LatLng *fromVtx,
 
 	while (node != NULL)
 	{
+		/*
+		 * A NULL toVtx means "any outgoing edge from this start". The polygon
+		 * walker uses that to choose the next half-edge after it has already
+		 * resolved ordering elsewhere.
+		 */
 		if (geoAlmostEqual(&node->from, fromVtx) &&
 			(toVtx == NULL || geoAlmostEqual(&node->to, toVtx)))
 			return node;
@@ -155,6 +182,10 @@ hash_vertex(const VertexGraph *graph, const LatLng *vertex)
 	if (graph->numBuckets <= 0)
 		return 0;
 
+	/*
+	 * Hashing only the start vertex matches the lookup pattern: reverse-edge
+	 * cancellation and polygon walking both begin with a known start point.
+	 */
 	return (uint32_t) fmod(fabs((vertex->lat + vertex->lng) * graph->resMultiplier),
 						   graph->numBuckets);
 }

--- a/h3_postgis/src/wkb_vertex_graph.c
+++ b/h3_postgis/src/wkb_vertex_graph.c
@@ -17,21 +17,43 @@
 
 #include <postgres.h>
 
+#include <stdint.h>
 #include <math.h>
+#include <utils/memutils.h>
 
 #include "wkb_vertex_graph.h"
 
 /*
- * This is a narrow replacement for H3's removed internal vertexGraph helper.
- * h3_postgis uses it only while rebuilding WKB polygons from H3 cell
- * boundaries that were split/noded for antimeridian and overlap handling.
+ * Vertex graph used by the h3_postgis WKB polygonizer.
  *
- * The graph stores directed boundary pieces. When the caller sees the same
- * segment in the opposite direction, it removes the existing edge instead of
- * adding another one; shared internal boundaries then disappear and only the
- * exterior polygon rings remain for polygonize_noded_graph().
+ * Historical context:
+ * H3 versions before 4.5 exposed an internal vertexGraph helper. h3_postgis
+ * used the same directed-edge cancellation model while converting H3 cell
+ * boundaries into planar WKB rings. H3 4.5 removed that private helper, and the
+ * replacement cellsToMultiPolygon path remains internal to H3 and does not
+ * replace h3_postgis' antimeridian-aware, noded WKB pipeline. This file is
+ * therefore the smallest graph primitive needed to preserve the existing
+ * h3_postgis polygonization semantics.
+ *
+ * Mathematical model:
+ * The graph behaves like a multiset of directed boundary segments with one
+ * cancellation rule. Adding segment A -> B stores that directed segment unless
+ * the opposite segment B -> A is already present; in that case the stored
+ * opposite segment is removed. Shared cell boundaries are emitted once by each
+ * adjacent cell in opposite directions, so they cancel. Segments that remain in
+ * the graph are boundary half-edges of the exterior polygonal arrangement and
+ * are consumed by polygonize_noded_graph().
+ *
+ * Scope of responsibility:
+ * This module does not classify rings, holes, winding order, containment, or
+ * antimeridian topology. wkb_regions.c is responsible for producing planar
+ * split/noded segments and for polygonizing the surviving half-edges. This
+ * module only stores, finds, and removes directed segments under H3's
+ * geoAlmostEqual() coordinate equality.
  */
 static uint32_t hash_vertex(const VertexGraph *graph, const LatLng *vertex);
+static uint64_t mix_uint64(uint64_t value);
+static void *palloc0_array_checked(Size count, Size elementSize);
 
 void
 initVertexGraph(VertexGraph *graph, int numBuckets, int res)
@@ -40,18 +62,25 @@ initVertexGraph(VertexGraph *graph, int numBuckets, int res)
 		numBuckets = 1;
 
 	/*
-	 * Keep buckets always allocated. The graph helpers index directly into this
-	 * array, so a zero-bucket graph would turn later add/find calls into NULL
-	 * dereferences.
+	 * numBuckets is a capacity hint derived by the caller from the expected
+	 * number of boundary segments. The table must nevertheless contain at least
+	 * one bucket because add/find/remove operations index the bucket array
+	 * directly.
+	 *
+	 * Buckets are only an acceleration structure. Candidate nodes selected by
+	 * the hash are always rechecked with geoAlmostEqual() on the relevant
+	 * endpoint(s), so hash collisions can increase scan length but cannot create
+	 * a false geometric match.
 	 */
-	graph->buckets = palloc0(numBuckets * sizeof(VertexNode *));
+	graph->buckets = palloc0_array_checked(numBuckets, sizeof(VertexNode *));
 	graph->numBuckets = numBuckets;
 	graph->size = 0;
 	graph->res = res;
 	/*
-	 * Coordinates are compared with geoAlmostEqual(). The hash only needs to
-	 * group nearby starts well enough to avoid scanning every edge; exact graph
-	 * identity is still checked with geoAlmostEqual() on both endpoints.
+	 * The hash uses quantized coordinates only to choose a likely bucket for the
+	 * start vertex. resMultiplier mirrors the historical H3 helper: lower H3
+	 * resolutions generate coarser boundary coordinates and therefore tolerate a
+	 * coarser hash quantization. Equality itself remains geoAlmostEqual().
 	 */
 	graph->resMultiplier = pow(10.0, 15 - res);
 }
@@ -59,7 +88,11 @@ initVertexGraph(VertexGraph *graph, int numBuckets, int res)
 void
 destroyVertexGraph(VertexGraph *graph)
 {
-	/* Nodes are owned by their bucket chains, so free each chain directly. */
+	/*
+	 * The graph owns the bucket array and every VertexNode in its chains. LatLng
+	 * endpoints are copied into each node, so destruction does not touch any
+	 * caller-owned coordinate storage.
+	 */
 	for (int i = 0; i < graph->numBuckets; i++)
 	{
 		VertexNode *node = graph->buckets[i];
@@ -92,6 +125,13 @@ addVertexNode(VertexGraph *graph, const LatLng *fromVtx, const LatLng *toVtx)
 	node->to = *toVtx;
 	node->next = NULL;
 
+	/*
+	 * Nodes are indexed by start vertex only. Both graph operations that need a
+	 * lookup begin with a known start point: reverse-edge cancellation searches
+	 * for B -> A before inserting A -> B, and ring walking asks for an outgoing
+	 * half-edge from the current vertex. The end vertex is therefore tested
+	 * after bucket selection rather than being part of the bucket key.
+	 */
 	currentNode = graph->buckets[index];
 	if (currentNode == NULL)
 	{
@@ -101,10 +141,19 @@ addVertexNode(VertexGraph *graph, const LatLng *fromVtx, const LatLng *toVtx)
 	{
 		for (;;)
 		{
-			/* Avoid inserting the same directed boundary piece twice. */
+			/*
+			 * The directed segment set is idempotent: inserting the same A -> B
+			 * segment again leaves the resident node in place and returns it.
+			 */
 			if (geoAlmostEqual(&currentNode->from, fromVtx) &&
 				geoAlmostEqual(&currentNode->to, toVtx))
 			{
+				/*
+				 * Duplicate directed pieces can appear after geometric splitting
+				 * and noding. Preserving the first node keeps pointer identity
+				 * stable for callers that already obtained a graph node and
+				 * matches the contract of the historical helper.
+				 */
 				pfree(node);
 				return currentNode;
 			}
@@ -148,6 +197,11 @@ removeVertexNode(VertexGraph *graph, VertexNode *node)
 	if (!found)
 		return 1;
 
+	/*
+	 * Removal is by node identity, not by a fresh coordinate search. That makes
+	 * the operation unambiguous when a bucket contains several outgoing segments
+	 * whose start coordinates are almost equal under geoAlmostEqual().
+	 */
 	pfree(node);
 	graph->size--;
 	return 0;
@@ -163,9 +217,13 @@ findNodeForEdge(const VertexGraph *graph, const LatLng *fromVtx,
 	while (node != NULL)
 	{
 		/*
-		 * A NULL toVtx means "any outgoing edge from this start". The polygon
-		 * walker uses that to choose the next half-edge after it has already
-		 * resolved ordering elsewhere.
+		 * Two lookup modes are required by the polygonization algorithm:
+		 *
+		 * - toVtx != NULL: exact directed-edge lookup under geoAlmostEqual(),
+		 *   used to decide whether the reverse segment is already present and
+		 *   should cancel the candidate insertion.
+		 * - toVtx == NULL: outgoing half-edge lookup, used by the ring walker
+		 *   after the next start vertex has already been determined.
 		 */
 		if (geoAlmostEqual(&node->from, fromVtx) &&
 			(toVtx == NULL || geoAlmostEqual(&node->to, toVtx)))
@@ -179,13 +237,55 @@ findNodeForEdge(const VertexGraph *graph, const LatLng *fromVtx,
 static uint32_t
 hash_vertex(const VertexGraph *graph, const LatLng *vertex)
 {
+	uint64_t	latHash;
+	uint64_t	lngHash;
+	int64_t		lat;
+	int64_t		lng;
+
 	if (graph->numBuckets <= 0)
 		return 0;
 
 	/*
-	 * Hashing only the start vertex matches the lookup pattern: reverse-edge
-	 * cancellation and polygon walking both begin with a known start point.
+	 * The hash is intentionally derived only from the start vertex because every
+	 * graph lookup is anchored at a start coordinate. Latitude and longitude are
+	 * quantized independently and mixed before combination; reducing a vertex to
+	 * lat+lng would systematically collide points on the same diagonal and make
+	 * dense polygon boundaries degrade toward long linear scans.
 	 */
-	return (uint32_t) fmod(fabs((vertex->lat + vertex->lng) * graph->resMultiplier),
-						   graph->numBuckets);
+	lat = (int64_t) llround(vertex->lat * graph->resMultiplier);
+	lng = (int64_t) llround(vertex->lng * graph->resMultiplier);
+	latHash = mix_uint64((uint64_t) lat);
+	lngHash = mix_uint64((uint64_t) lng);
+	return (uint32_t) ((latHash ^ (lngHash + UINT64_C(0x9e3779b97f4a7c15)
+								   + (latHash << 6) + (latHash >> 2)))
+					   % (uint64_t) graph->numBuckets);
+}
+
+static uint64_t
+mix_uint64(uint64_t value)
+{
+	/*
+	 * SplitMix64 finalizer used as a small non-cryptographic avalanche step.
+	 * The graph is not a security boundary; the goal is deterministic diffusion
+	 * of quantized coordinate integers across the caller-provided bucket count.
+	 */
+	value ^= value >> 30;
+	value *= UINT64_C(0xbf58476d1ce4e5b9);
+	value ^= value >> 27;
+	value *= UINT64_C(0x94d049bb133111eb);
+	value ^= value >> 31;
+	return value;
+}
+
+static void *
+palloc0_array_checked(Size count, Size elementSize)
+{
+	/*
+	 * Guard the arithmetic before calling palloc0(). PostgreSQL checks whether
+	 * the final allocation size is valid, but it cannot detect an overflow that
+	 * already occurred while computing count * elementSize.
+	 */
+	if (elementSize != 0 && count > MaxAllocSize / elementSize)
+		elog(ERROR, "too many vertex graph buckets");
+	return palloc0(count * elementSize);
 }

--- a/h3_postgis/src/wkb_vertex_graph.h
+++ b/h3_postgis/src/wkb_vertex_graph.h
@@ -22,6 +22,11 @@
 
 typedef struct VertexNode VertexNode;
 
+/*
+ * Directed boundary segment used while polygonizing split H3 cell boundaries.
+ * A node is keyed by its start vertex; the end vertex is still part of identity
+ * so duplicate directed edges collapse to a single graph entry.
+ */
 struct VertexNode
 {
 	LatLng		from;
@@ -29,6 +34,14 @@ struct VertexNode
 	VertexNode *next;
 };
 
+/*
+ * Small hash table for directed boundary segments.
+ *
+ * H3 4.5 no longer ships the old internal vertexGraph helper that this WKB
+ * polygonizer used. This struct intentionally keeps only the operations needed
+ * by h3_postgis: add an edge, find an exact/reverse edge, and remove it when
+ * shared boundaries cancel during polygon union construction.
+ */
 typedef struct
 {
 	VertexNode **buckets;

--- a/h3_postgis/src/wkb_vertex_graph.h
+++ b/h3_postgis/src/wkb_vertex_graph.h
@@ -35,6 +35,7 @@ typedef struct
 	int			numBuckets;
 	int			size;
 	int			res;
+	double		resMultiplier;
 } VertexGraph;
 
 void initVertexGraph(VertexGraph *graph, int numBuckets, int res);

--- a/h3_postgis/src/wkb_vertex_graph.h
+++ b/h3_postgis/src/wkb_vertex_graph.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017, 2020-2021 Uber Technologies, Inc.
+ * Copyright 2026 Darafei Praliaskouski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WKB_VERTEX_GRAPH_H
+#define WKB_VERTEX_GRAPH_H
+
+#include <latLng.h>
+
+typedef struct VertexNode VertexNode;
+
+struct VertexNode
+{
+	LatLng		from;
+	LatLng		to;
+	VertexNode *next;
+};
+
+typedef struct
+{
+	VertexNode **buckets;
+	int			numBuckets;
+	int			size;
+	int			res;
+} VertexGraph;
+
+void initVertexGraph(VertexGraph *graph, int numBuckets, int res);
+void destroyVertexGraph(VertexGraph *graph);
+VertexNode *addVertexNode(VertexGraph *graph, const LatLng *fromVtx,
+						  const LatLng *toVtx);
+int removeVertexNode(VertexGraph *graph, VertexNode *node);
+VertexNode *findNodeForEdge(const VertexGraph *graph, const LatLng *fromVtx,
+							const LatLng *toVtx);
+
+#endif

--- a/h3_postgis/test/expected/postgis.out
+++ b/h3_postgis/test/expected/postgis.out
@@ -107,6 +107,21 @@ SELECT ST_Equals(
 );
  t
 
+-- H3 v4.5.0 rejects ambiguous duplicate-cell outlines instead of producing
+-- undefined multipolygon output.
+CREATE FUNCTION h3_test_cells_to_multi_polygon_geometry_duplicate() RETURNS boolean LANGUAGE PLPGSQL
+    AS $$
+        BEGIN
+            PERFORM h3_cells_to_multi_polygon_geometry(ARRAY['880326b885fffff'::h3index, '880326b885fffff'::h3index]);
+            RETURN false;
+        EXCEPTION WHEN OTHERS THEN
+            RETURN true;
+        END;
+    $$;
+SELECT h3_test_cells_to_multi_polygon_geometry_duplicate();
+ t
+
+DROP FUNCTION h3_test_cells_to_multi_polygon_geometry_duplicate;
 -- invalid polygon can produce a very large number of cells (upstream H3 behavior)
 SET client_min_messages TO warning;
 \set invalid_res 5

--- a/h3_postgis/test/expected/postgis.out
+++ b/h3_postgis/test/expected/postgis.out
@@ -397,6 +397,18 @@ SELECT ST_IsValid(h3_cells_to_multi_polygon_geometry(arr))
 FROM cells;
  t
 
+-- antimeridian neighborhoods exercise split/noded reverse-edge cancellation
+WITH cells AS (
+    SELECT array_agg(h3 ORDER BY h3) AS arr
+    FROM (
+        SELECT h3_grid_disk(:edgecross, 1) AS h3
+    ) q
+)
+SELECT ST_IsValid(h3_cells_to_multi_polygon_geometry(arr))
+   AND NOT ST_IsEmpty(h3_cells_to_multi_polygon_geometry(arr))
+FROM cells;
+ t
+
 -- representative low-zoom tile cover remains both valid and covering
 WITH tile AS (
     SELECT ST_Transform(ST_TileEnvelope(3, 0, 1), 4326) AS tile,

--- a/h3_postgis/test/sql/postgis.sql
+++ b/h3_postgis/test/sql/postgis.sql
@@ -100,6 +100,20 @@ SELECT ST_Equals(
     h3_cells_to_multi_polygon_geometry(ARRAY[:hexagon::h3index])
 );
 
+-- H3 v4.5.0 rejects ambiguous duplicate-cell outlines instead of producing
+-- undefined multipolygon output.
+CREATE FUNCTION h3_test_cells_to_multi_polygon_geometry_duplicate() RETURNS boolean LANGUAGE PLPGSQL
+    AS $$
+        BEGIN
+            PERFORM h3_cells_to_multi_polygon_geometry(ARRAY['880326b885fffff'::h3index, '880326b885fffff'::h3index]);
+            RETURN false;
+        EXCEPTION WHEN OTHERS THEN
+            RETURN true;
+        END;
+    $$;
+SELECT h3_test_cells_to_multi_polygon_geometry_duplicate();
+DROP FUNCTION h3_test_cells_to_multi_polygon_geometry_duplicate;
+
 -- invalid polygon can produce a very large number of cells (upstream H3 behavior)
 SET client_min_messages TO warning;
 \set invalid_res 5

--- a/h3_postgis/test/sql/postgis.sql
+++ b/h3_postgis/test/sql/postgis.sql
@@ -372,6 +372,17 @@ WITH cells AS (
 SELECT ST_IsValid(h3_cells_to_multi_polygon_geometry(arr))
 FROM cells;
 
+-- antimeridian neighborhoods exercise split/noded reverse-edge cancellation
+WITH cells AS (
+    SELECT array_agg(h3 ORDER BY h3) AS arr
+    FROM (
+        SELECT h3_grid_disk(:edgecross, 1) AS h3
+    ) q
+)
+SELECT ST_IsValid(h3_cells_to_multi_polygon_geometry(arr))
+   AND NOT ST_IsEmpty(h3_cells_to_multi_polygon_geometry(arr))
+FROM cells;
+
 -- representative low-zoom tile cover remains both valid and covering
 WITH tile AS (
     SELECT ST_Transform(ST_TileEnvelope(3, 0, 1), 4326) AS tile,


### PR DESCRIPTION
## Summary

- bump the bundled H3 core library from v4.4.1 to v4.5.0
- expose the new public `reverseDirectedEdge` API as `h3_reverse_directed_edge(edge h3index)` in install and upgrade SQL
- keep `h3_postgis` antimeridian/polar polygon fallback working after H3 v4.5.0 removed the old internal `vertexGraph` helper by moving the small graph helper into `h3_postgis`
- add regression coverage for reversed directed edges, bidirectional `h3_grid_path_cells`, and v4.5.0 duplicate-cell validation in both core and PostGIS multipolygon wrappers

Upstream H3 v4.5.0 release notes: https://github.com/uber/h3/releases/tag/v4.5.0

## Tests

- `./scripts/check-metadata`
- `./scripts/documentation`
- `cmake --build build -j 32`
- `PATH=/home/kom/.cargo/bin:$PATH ctest --test-dir build --output-on-failure -j 1`
