### PR TITLE
Harden release automation

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -21,14 +21,16 @@ This command also validates that all extension GUCs are documented in `h3/src/gu
 
 ## Release Process
 
-1. Update version number
-   - Don't follow semver, simply use major and minor from H3 core and increment patch.
-   - Version number should be changed in root `CMakeLists.txt`.
-   - Set `INSTALL_VERSION` to "${PROJECT_VERSION}".
-   - Update files (and cmake references) suffixed `--unreleased` should be renamed.
-   - Installer `.sql` files should have `@ availability` comments updated.
-   - Update changelog by moving from `Unreleased` to a new section
-   - Push and merge changes in `release-x.y.z` branch.
+1. Prepare a release branch
+   - Don't follow semver blindly: use major and minor from H3 core and increment
+     the h3-pg patch independently.
+   - Run `scripts/release X.Y.Z`. Set `RELEASE_DATE=YYYY-MM-DD` only when the
+     release date should differ from today.
+   - The script creates `release-X.Y.Z`, updates version metadata, renames
+     `--unreleased` update SQL files, updates availability/docs/changelog,
+     updates release-sensitive regression targets, and runs release metadata
+     checks.
+   - Review, commit, push, and merge the `release-X.Y.Z` branch.
 2. Create a release on GitHub
    - Draft new release "vX.Y.Z"
    - Copy CHANGELOG.md entry into release description
@@ -36,6 +38,6 @@ This command also validates that all extension GUCs are documented in `h3/src/gu
    - Run `scripts/bundle` to package the release
    - Upload the distribution on [PGXN Manager](https://manager.pgxn.org/)
 4. Prepare for development
-   - Set `INSTALL_VERSION` to `unreleased` in root `CMakeLists.txt`.
-   - Create new update files with `--unreleased` suffix.
-   - Add them to relevant `CMakeLists.txt` files.
+   - Run `scripts/postrelease` to restore `INSTALL_VERSION=unreleased`, create
+     the next empty update SQL files, and add them to the extension CMake files.
+   - Review, commit, push, and merge the post-release development branch.

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,9 +43,13 @@ This command also validates that all extension GUCs are documented in `h3/src/gu
 3. Commit and merge the release branch
    - Commit the reviewed release changes.
    - Push and merge `release-X.Y.Z`.
-4. Create a release on GitHub
-   - Draft new release "vX.Y.Z"
-   - Copy CHANGELOG.md entry into release description
+4. Publish the GitHub release
+   - This is a maintainer action, not part of `scripts/release`. The release
+     manager, or another maintainer with GitHub release permissions, publishes
+     the release after `release-X.Y.Z` is merged.
+   - Create or draft release `vX.Y.Z` from the merged release commit on `main`.
+     If GitHub creates the tag, verify that tag `vX.Y.Z` points at that commit.
+   - Copy the `CHANGELOG.md` entry into the release description.
 5. Distribute the extension on PGXN
    - Run `scripts/bundle` to package the release
    - Upload the distribution on [PGXN Manager](https://manager.pgxn.org/)

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,23 +21,39 @@ This command also validates that all extension GUCs are documented in `h3/src/gu
 
 ## Release Process
 
-1. Prepare a release branch
-   - Don't follow semver blindly: use major and minor from H3 core and increment
-     the h3-pg patch independently.
+1. Prepare the release branch
+   - Pick `X.Y.Z`. The `X.Y` part must match the bundled H3 core version; bump
+     only the h3-pg patch when H3 core has not changed.
+   - Start from a clean tracked worktree on the branch you want to release from.
    - Run `scripts/release X.Y.Z`. Set `RELEASE_DATE=YYYY-MM-DD` only when the
-     release date should differ from today.
-   - The script creates `release-X.Y.Z`, updates version metadata, renames
-     `--unreleased` update SQL files, updates availability/docs/changelog,
-     updates release-sensitive regression targets, and runs release metadata
-     checks.
-   - Review, commit, push, and merge the `release-X.Y.Z` branch.
-2. Create a release on GitHub
+     changelog and citation date should differ from today.
+   - The script creates `release-X.Y.Z` and leaves the release changes
+     uncommitted for review.
+2. Review the release diff
+   - Root `CMakeLists.txt` has `VERSION X.Y.Z` and installs
+     `${PROJECT_VERSION}` instead of `unreleased`.
+   - The `h3` and `h3_postgis` update files that ended in `--unreleased.sql`
+     have been renamed to end in `--X.Y.Z.sql`, and their CMake references were
+     renamed with them.
+   - Installer SQL availability comments, generated API documentation,
+     `CITATION.cff`, `CHANGELOG.md`, and the extension upgrade regression target
+     all refer to `X.Y.Z`.
+   - `scripts/check-metadata` and `git diff --check` passed at the end of the
+     script run.
+3. Commit and merge the release branch
+   - Commit the reviewed release changes.
+   - Push and merge `release-X.Y.Z`.
+4. Create a release on GitHub
    - Draft new release "vX.Y.Z"
    - Copy CHANGELOG.md entry into release description
-3. Distribute the extension on PGXN
+5. Distribute the extension on PGXN
    - Run `scripts/bundle` to package the release
    - Upload the distribution on [PGXN Manager](https://manager.pgxn.org/)
-4. Prepare for development
-   - Run `scripts/postrelease` to restore `INSTALL_VERSION=unreleased`, create
-     the next empty update SQL files, and add them to the extension CMake files.
+6. Prepare the next development cycle
+   - After the release branch is merged, start from the updated main branch.
+   - Run `scripts/postrelease`. The script restores `INSTALL_VERSION` to
+     `unreleased`, creates the next empty `h3--X.Y.Z--unreleased.sql` and
+     `h3_postgis--X.Y.Z--unreleased.sql` files, adds them to the extension CMake
+     files, restores the upgrade regression target to `unreleased`, and runs the
+     release metadata checks.
    - Review, commit, push, and merge the post-release development branch.

--- a/scripts/postrelease
+++ b/scripts/postrelease
@@ -19,9 +19,8 @@ make_next_update() {
   local version="$4"
   local release_file next_file release_name next_name tmp
 
-  release_file="${update_dir}/${extname}--"*--"${version}.sql"
   shopt -s nullglob
-  local matches=($release_file)
+  local matches=("${update_dir}/${extname}--"*--"${version}.sql")
   shopt -u nullglob
 
   if [[ ${#matches[@]} -ne 1 ]]; then
@@ -84,7 +83,7 @@ main() {
   require_clean_tracked_tree
 
   sed -i '/set(INSTALL_VERSION "unreleased/s/^#//g' CMakeLists.txt
-  sed -i '/set(INSTALL_VERSION "${PROJECT_VERSION}")/s/^/#/g' CMakeLists.txt
+  sed -i "/set(INSTALL_VERSION \"\${PROJECT_VERSION}\")/s/^/#/g" CMakeLists.txt
 
   make_next_update h3 h3/sql/updates h3/CMakeLists.txt "$version"
   make_next_update h3_postgis h3_postgis/sql/updates h3_postgis/CMakeLists.txt "$version"

--- a/scripts/postrelease
+++ b/scripts/postrelease
@@ -40,10 +40,24 @@ make_next_update() {
     sed "s/UPDATE TO '${version}'/UPDATE TO 'unreleased'/" > "$next_file"
 
   tmp="$(mktemp)"
-  awk -v needle="$release_name" -v addition="    sql/updates/${next_name}" '
-    { print }
-    index($0, needle) { print addition }
-  ' "$cmake_file" > "$tmp"
+  awk -v needle="    sql/updates/${release_name}" -v addition="    sql/updates/${next_name}" '
+    {
+      print
+      if ($0 == needle) {
+        print addition
+        hits++
+      }
+    }
+    END {
+      if (hits != 1) {
+        exit 42
+      }
+    }
+  ' "$cmake_file" > "$tmp" || {
+    rm -f "$tmp"
+    rm -f "$next_file"
+    die "${cmake_file} must contain exactly one sql/updates/${release_name} entry"
+  }
   mv "$tmp" "$cmake_file"
 }
 
@@ -76,8 +90,10 @@ main() {
   make_next_update h3_postgis h3_postgis/sql/updates h3_postgis/CMakeLists.txt "$version"
   sed -i "s/ALTER EXTENSION h3 UPDATE TO '${version}'/ALTER EXTENSION h3 UPDATE TO 'unreleased'/g" \
     h3/test/sql/extension.sql h3/test/expected/extension.out
-  grep -q "ALTER EXTENSION h3 UPDATE TO 'unreleased'" h3/test/sql/extension.sql ||
-    die "h3 extension regression test was not restored to unreleased"
+  for test_file in h3/test/sql/extension.sql h3/test/expected/extension.out; do
+    grep -q "ALTER EXTENSION h3 UPDATE TO 'unreleased'" "$test_file" ||
+      die "${test_file} extension regression target was not restored to unreleased"
+  done
 
   verify_update_references
   scripts/check-metadata

--- a/scripts/postrelease
+++ b/scripts/postrelease
@@ -1,21 +1,89 @@
 #!/usr/bin/env bash
 
-set -u
+set -euo pipefail
 
-VERSION=$(sed -rnE 's/  VERSION ([0-9\.]+)/\1/p' CMakeLists.txt)
-echo $VERSION
+die() {
+  echo "postrelease: $*" >&2
+  exit 1
+}
 
-# Set `INSTALL_VERSION` to `unreleased` in root `CMakeLists.txt`.
-sed -i '/set(INSTALL_VERSION "unreleased/s/^#//g' CMakeLists.txt
-sed -i '/set(INSTALL_VERSION "${PROJECT_VERSION}")/s/^/#/g' CMakeLists.txt
+require_clean_tracked_tree() {
+  git diff --quiet || die "tracked worktree changes are present"
+  git diff --cached --quiet || die "staged changes are present"
+}
 
-# Create new update files with `--unreleased` suffix.
-cp h3/sql/updates/h3--4.2.1--4.2.2.sql h3/sql/updates/h3--$VERSION--unreleased.sql
-sed -i "s/4.2.2/unreleased/g" h3/sql/updates/h3--$VERSION--unreleased.sql
+make_next_update() {
+  local extname="$1"
+  local update_dir="$2"
+  local cmake_file="$3"
+  local version="$4"
+  local release_file next_file release_name next_name tmp
 
-cp h3_postgis/sql/updates/h3_postgis--4.2.1--4.2.2.sql h3_postgis/sql/updates/h3_postgis--$VERSION--unreleased.sql
-sed -i "s/4.2.2/unreleased/g" h3_postgis/sql/updates/h3_postgis--$VERSION--unreleased.sql
+  release_file="${update_dir}/${extname}--"*--"${version}.sql"
+  shopt -s nullglob
+  local matches=($release_file)
+  shopt -u nullglob
 
-# Add them to relevant `CMakeLists.txt` files.
-sed -i "/--$VERSION.sql/a\ \ \ \ sql/updates/h3--$VERSION--unreleased.sql" h3/CMakeLists.txt
-sed -i "/--$VERSION.sql/a\ \ \ \ sql/updates/h3_postgis--$VERSION--unreleased.sql" h3_postgis/CMakeLists.txt
+  if [[ ${#matches[@]} -ne 1 ]]; then
+    die "expected exactly one released ${update_dir}/${extname}--*--${version}.sql, found ${#matches[@]}"
+  fi
+
+  release_file="${matches[0]}"
+  next_file="${update_dir}/${extname}--${version}--unreleased.sql"
+  release_name="$(basename "$release_file")"
+  next_name="$(basename "$next_file")"
+
+  [[ ! -e "$next_file" ]] || die "${next_file} already exists"
+  grep -qF "$release_name" "$cmake_file" || die "${cmake_file} does not reference ${release_name}"
+
+  sed -n '1,/^\\echo /p' "$release_file" |
+    sed "s/UPDATE TO '${version}'/UPDATE TO 'unreleased'/" > "$next_file"
+
+  tmp="$(mktemp)"
+  awk -v needle="$release_name" -v addition="    sql/updates/${next_name}" '
+    { print }
+    index($0, needle) { print addition }
+  ' "$cmake_file" > "$tmp"
+  mv "$tmp" "$cmake_file"
+}
+
+verify_update_references() {
+  local cmake_file update_path
+
+  for cmake_file in h3/CMakeLists.txt h3_postgis/CMakeLists.txt; do
+    while IFS= read -r update_path; do
+      [[ -f "$(dirname "$cmake_file")/${update_path}" ]] ||
+        die "${cmake_file} references missing ${update_path}"
+    done < <(grep -oE 'sql/updates/[A-Za-z0-9_.-]+\.sql' "$cmake_file")
+  done
+}
+
+main() {
+  local repo_root version
+
+  repo_root="$(git rev-parse --show-toplevel)"
+  cd "$repo_root"
+
+  version="$(sed -rnE 's/^  VERSION ([0-9]+\.[0-9]+\.[0-9]+)/\1/p' CMakeLists.txt)"
+  [[ -n "$version" ]] || die "could not parse project version from CMakeLists.txt"
+
+  require_clean_tracked_tree
+
+  sed -i '/set(INSTALL_VERSION "unreleased/s/^#//g' CMakeLists.txt
+  sed -i '/set(INSTALL_VERSION "${PROJECT_VERSION}")/s/^/#/g' CMakeLists.txt
+
+  make_next_update h3 h3/sql/updates h3/CMakeLists.txt "$version"
+  make_next_update h3_postgis h3_postgis/sql/updates h3_postgis/CMakeLists.txt "$version"
+  sed -i "s/ALTER EXTENSION h3 UPDATE TO '${version}'/ALTER EXTENSION h3 UPDATE TO 'unreleased'/g" \
+    h3/test/sql/extension.sql h3/test/expected/extension.out
+  grep -q "ALTER EXTENSION h3 UPDATE TO 'unreleased'" h3/test/sql/extension.sql ||
+    die "h3 extension regression test was not restored to unreleased"
+
+  verify_update_references
+  scripts/check-metadata
+  git diff --check
+
+  echo "Post-release development files for ${version} -> unreleased are prepared."
+}
+
+main "$@"

--- a/scripts/release
+++ b/scripts/release
@@ -179,11 +179,12 @@ verify_release_state() {
 }
 
 main() {
-  local version="${1:-}"
+  [[ $# -eq 1 ]] || { usage; exit 2; }
+
+  local version="$1"
   local release_date="${RELEASE_DATE:-$(date +%F)}"
   local repo_root h3_core_version
 
-  [[ -n "$version" ]] || { usage; exit 2; }
   [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be X.Y.Z"
   [[ "$release_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] ||
     die "RELEASE_DATE must be YYYY-MM-DD"

--- a/scripts/release
+++ b/scripts/release
@@ -79,14 +79,28 @@ release_update_file() {
     perl -0pi -e 's/\Q$ENV{OLD_NAME}\E/$ENV{NEW_NAME}/g' "$cmake_file"
 }
 
+changelog_previous_version() {
+  sed -nE 's#^\[unreleased\]: .*/compare/v([0-9]+\.[0-9]+\.[0-9]+)\.\.\.HEAD$#\1#p' CHANGELOG.md
+}
+
+require_changelog_release_ready() {
+  local version="$1"
+  local previous_version
+
+  previous_version="$(changelog_previous_version)"
+  [[ -n "$previous_version" ]] || die "could not determine previous version from CHANGELOG.md [unreleased] link"
+  if grep -qF "## [${version}]" CHANGELOG.md || grep -qF "[${version}]:" CHANGELOG.md; then
+    die "CHANGELOG.md already has a [${version}] release entry"
+  fi
+}
+
 update_changelog() {
   local version="$1"
   local release_date="$2"
   local previous_version tmp
 
-  previous_version="$(sed -nE 's#^\[unreleased\]: .*/compare/v([0-9]+\.[0-9]+\.[0-9]+)\.\.\.HEAD$#\1#p' CHANGELOG.md)"
-  [[ -n "$previous_version" ]] || die "could not determine previous version from CHANGELOG.md [unreleased] link"
-  ! grep -q "^\[${version}\]:" CHANGELOG.md || die "CHANGELOG.md already has a [${version}] link"
+  require_changelog_release_ready "$version"
+  previous_version="$(changelog_previous_version)"
 
   tmp="$(mktemp)"
   awk -v version="$version" -v release_date="$release_date" '
@@ -182,6 +196,7 @@ main() {
   [[ "${version%.*}" == "${h3_core_version%.*}" ]] ||
     die "h3-pg major.minor (${version%.*}) must match H3 core major.minor (${h3_core_version%.*})"
 
+  require_changelog_release_ready "$version"
   require_clean_tracked_tree
   release_branch "$version"
 

--- a/scripts/release
+++ b/scripts/release
@@ -1,33 +1,218 @@
 #!/usr/bin/env bash
 
-set -u
-VERSION="$1"
-: "$VERSION"
+set -euo pipefail
 
-# Version number should be changed in root `CMakeLists.txt`.
-sed -i -r "s/(  VERSION )[0-9\.]+/\1$VERSION/g" CMakeLists.txt
+usage() {
+  echo "Usage: scripts/release X.Y.Z" >&2
+  echo "Set RELEASE_DATE=YYYY-MM-DD to override the changelog/CITATION date." >&2
+}
 
-# Set `INSTALL_VERSION` to "${PROJECT_VERSION}".
-sed -i '/set(INSTALL_VERSION "${PROJECT_VERSION}")/s/^#//g' CMakeLists.txt
-sed -i '/set(INSTALL_VERSION "unreleased")/s/^/#/g' CMakeLists.txt
+die() {
+  echo "release: $*" >&2
+  exit 1
+}
 
-# Installer `.sql` files should have `@ availability` comments updated.
-sed -i "s/availability: unreleased/availability: $VERSION/g" h3/sql/install/*.sql
-sed -i "s/availability: unreleased/availability: $VERSION/g" h3_postgis/sql/install/*.sql
+require_clean_tracked_tree() {
+  git diff --quiet || die "tracked worktree changes are present"
+  git diff --cached --quiet || die "staged changes are present"
+}
 
-# Update files (and cmake references) suffixed `--unreleased` should be renamed.
-rename unreleased "$VERSION" h3/sql/updates/*--unreleased.sql
-sed -i "s/unreleased/$VERSION/g" h3/sql/updates/*--$VERSION.sql
-sed -i "s/unreleased/$VERSION/g" h3/CMakeLists.txt
+release_branch() {
+  local version="$1"
+  local branch="release-${version}"
+  local current_branch
 
-rename unreleased "$VERSION" h3_postgis/sql/updates/*--unreleased.sql
-sed -i "s/unreleased/$VERSION/g" h3_postgis/sql/updates/*--$VERSION.sql
-sed -i "s/unreleased/$VERSION/g" h3_postgis/CMakeLists.txt
+  current_branch="$(git branch --show-current || true)"
+  if [[ "$current_branch" == "$branch" ]]; then
+    return
+  fi
+  if git show-ref --verify --quiet "refs/heads/${branch}"; then
+    die "branch ${branch} already exists; switch to it or delete it first"
+  fi
+  git switch -c "$branch"
+}
 
-# Generate docs
-scripts/documentation
+require_match() {
+  local pattern="$1"
+  local path="$2"
 
-git checkout -b "release-$VERSION"
+  grep -qE "$pattern" "$path" || die "${path} does not match ${pattern}"
+}
 
-echo "Remember to":
-echo "   - Update changelog by moving from \`Unreleased\` to a new section"
+replace_required() {
+  local pattern="$1"
+  local replacement="$2"
+  local path="$3"
+
+  require_match "$pattern" "$path"
+  sed -i -E "s#${pattern}#${replacement}#" "$path"
+}
+
+release_update_file() {
+  local extname="$1"
+  local update_dir="$2"
+  local cmake_file="$3"
+  local version="$4"
+  local matches old_file new_file old_name new_name
+
+  shopt -s nullglob
+  matches=("${update_dir}/${extname}--"*--unreleased.sql)
+  shopt -u nullglob
+
+  if [[ ${#matches[@]} -ne 1 ]]; then
+    die "expected exactly one ${update_dir}/${extname}--*--unreleased.sql, found ${#matches[@]}"
+  fi
+
+  old_file="${matches[0]}"
+  new_file="${old_file/--unreleased.sql/--${version}.sql}"
+  old_name="$(basename "$old_file")"
+  new_name="$(basename "$new_file")"
+
+  [[ "$old_file" != "$new_file" ]] || die "refusing to rename ${old_file} to itself"
+  [[ ! -e "$new_file" ]] || die "${new_file} already exists"
+
+  git mv "$old_file" "$new_file"
+  sed -i "s/unreleased/${version}/g" "$new_file"
+  sed -i -E 's/[[:space:]]+$//' "$new_file"
+  grep -qF "$old_name" "$cmake_file" || die "${cmake_file} does not reference ${old_name}"
+  OLD_NAME="$old_name" NEW_NAME="$new_name" \
+    perl -0pi -e 's/\Q$ENV{OLD_NAME}\E/$ENV{NEW_NAME}/g' "$cmake_file"
+}
+
+update_changelog() {
+  local version="$1"
+  local release_date="$2"
+  local previous_version tmp
+
+  previous_version="$(sed -nE 's#^\[unreleased\]: .*/compare/v([0-9]+\.[0-9]+\.[0-9]+)\.\.\.HEAD$#\1#p' CHANGELOG.md)"
+  [[ -n "$previous_version" ]] || die "could not determine previous version from CHANGELOG.md [unreleased] link"
+  ! grep -q "^\[${version}\]:" CHANGELOG.md || die "CHANGELOG.md already has a [${version}] link"
+
+  tmp="$(mktemp)"
+  awk -v version="$version" -v release_date="$release_date" '
+    BEGIN { released = 0; in_release = 0; skip_summary = 0 }
+    !released && $0 == "## [Unreleased]" {
+      print "## [Unreleased]"
+      print ""
+      print "## [" version "] - " release_date
+      released = 1
+      in_release = 1
+      next
+    }
+    in_release && $0 ~ /^[[:space:]]*<details>[[:space:]]*$/ {
+      skip_summary = 1
+      next
+    }
+    skip_summary {
+      if ($0 ~ /^[[:space:]]*<\/summary>[[:space:]]*$/)
+        skip_summary = 0
+      next
+    }
+    in_release && $0 ~ /^[[:space:]]*<\/details>[[:space:]]*$/ {
+      next
+    }
+    in_release && $0 ~ /^## \[/ {
+      in_release = 0
+    }
+    { print }
+  ' CHANGELOG.md > "$tmp"
+  mv "$tmp" CHANGELOG.md
+
+  tmp="$(mktemp)"
+  awk -v version="$version" -v previous="v${previous_version}" '
+    /^\[unreleased\]: / {
+      print "[unreleased]: https://github.com/postgis/h3-pg/compare/v" version "...HEAD"
+      print "[" version "]: https://github.com/postgis/h3-pg/compare/" previous "...v" version
+      next
+    }
+    { print }
+  ' CHANGELOG.md > "$tmp"
+  mv "$tmp" CHANGELOG.md
+}
+
+verify_update_references() {
+  local cmake_file update_path
+
+  for cmake_file in h3/CMakeLists.txt h3_postgis/CMakeLists.txt; do
+    while IFS= read -r update_path; do
+      [[ -f "$(dirname "$cmake_file")/${update_path}" ]] ||
+        die "${cmake_file} references missing ${update_path}"
+    done < <(grep -oE 'sql/updates/[A-Za-z0-9_.-]+\.sql' "$cmake_file")
+  done
+}
+
+verify_release_state() {
+  local version="$1"
+
+  verify_update_references
+
+  if find h3/sql/updates h3_postgis/sql/updates -name '*--unreleased.sql' | grep -q .; then
+    find h3/sql/updates h3_postgis/sql/updates -name '*--unreleased.sql' >&2
+    die "unreleased update files remain after release"
+  fi
+
+  if grep -R -n -E 'availability: unreleased|Since vunreleased|UPDATE TO '\''unreleased'\''|--unreleased\.sql' \
+      h3 h3_postgis docs/api.md CMakeLists.txt; then
+    die "unreleased release markers remain"
+  fi
+
+  grep -q "VERSION ${version}" CMakeLists.txt || die "CMakeLists.txt project version was not updated"
+  grep -q 'set(INSTALL_VERSION "${PROJECT_VERSION}")' CMakeLists.txt ||
+    die "INSTALL_VERSION is not set to PROJECT_VERSION"
+
+  scripts/check-metadata
+  git diff --check
+}
+
+main() {
+  local version="${1:-}"
+  local release_date="${RELEASE_DATE:-$(date +%F)}"
+  local repo_root h3_core_version
+
+  [[ -n "$version" ]] || { usage; exit 2; }
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be X.Y.Z"
+  [[ "$release_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] ||
+    die "RELEASE_DATE must be YYYY-MM-DD"
+
+  repo_root="$(git rev-parse --show-toplevel)"
+  cd "$repo_root"
+
+  h3_core_version="$(sed -rnE 's/^set\(H3_CORE_VERSION ([0-9]+\.[0-9]+\.[0-9]+)\)/\1/p' CMakeLists.txt)"
+  [[ -n "$h3_core_version" ]] || die "could not parse H3_CORE_VERSION"
+  [[ "${version%.*}" == "${h3_core_version%.*}" ]] ||
+    die "h3-pg major.minor (${version%.*}) must match H3 core major.minor (${h3_core_version%.*})"
+
+  require_clean_tracked_tree
+  release_branch "$version"
+
+  replace_required '  VERSION [0-9]+\.[0-9]+\.[0-9]+' "  VERSION ${version}" CMakeLists.txt
+  sed -i '/set(INSTALL_VERSION "${PROJECT_VERSION}")/s/^#//g' CMakeLists.txt
+  sed -i '/set(INSTALL_VERSION "unreleased")/s/^/#/g' CMakeLists.txt
+
+  sed -i "s/availability: unreleased/availability: ${version}/g" h3/sql/install/*.sql
+  sed -i "s/availability: unreleased/availability: ${version}/g" h3_postgis/sql/install/*.sql
+
+  release_update_file h3 h3/sql/updates h3/CMakeLists.txt "$version"
+  release_update_file h3_postgis h3_postgis/sql/updates h3_postgis/CMakeLists.txt "$version"
+
+  sed -i "s/ALTER EXTENSION h3 UPDATE TO 'unreleased'/ALTER EXTENSION h3 UPDATE TO '${version}'/g" \
+    h3/test/sql/extension.sql h3/test/expected/extension.out
+
+  sed -i -E "s/^version: v[0-9]+\.[0-9]+\.[0-9]+/version: v${version}/" CITATION.cff
+  sed -i -E "s/^date-released: [0-9]{4}-[0-9]{2}-[0-9]{2}/date-released: ${release_date}/" CITATION.cff
+
+  update_changelog "$version" "$release_date"
+
+  scripts/documentation
+  verify_release_state "$version"
+
+  echo "Release branch release-${version} is prepared."
+  echo "Next:"
+  echo "  - review and commit the release-${version} changes"
+  echo "  - push and merge the release branch"
+  echo "  - draft GitHub release v${version} from CHANGELOG.md"
+  echo "  - run scripts/bundle and upload to PGXN"
+  echo "  - run scripts/postrelease after the release is merged"
+}
+
+main "$@"

--- a/scripts/release
+++ b/scripts/release
@@ -210,7 +210,7 @@ main() {
   echo "Next:"
   echo "  - review and commit the release-${version} changes"
   echo "  - push and merge the release branch"
-  echo "  - draft GitHub release v${version} from CHANGELOG.md"
+  echo "  - have the release manager publish GitHub release v${version} from CHANGELOG.md"
   echo "  - run scripts/bundle and upload to PGXN"
   echo "  - run scripts/postrelease after the release is merged"
 }

--- a/scripts/release
+++ b/scripts/release
@@ -157,7 +157,7 @@ verify_release_state() {
   fi
 
   grep -q "VERSION ${version}" CMakeLists.txt || die "CMakeLists.txt project version was not updated"
-  grep -q 'set(INSTALL_VERSION "${PROJECT_VERSION}")' CMakeLists.txt ||
+  grep -q "set(INSTALL_VERSION \"\${PROJECT_VERSION}\")" CMakeLists.txt ||
     die "INSTALL_VERSION is not set to PROJECT_VERSION"
 
   scripts/check-metadata
@@ -186,7 +186,7 @@ main() {
   release_branch "$version"
 
   replace_required '  VERSION [0-9]+\.[0-9]+\.[0-9]+' "  VERSION ${version}" CMakeLists.txt
-  sed -i '/set(INSTALL_VERSION "${PROJECT_VERSION}")/s/^#//g' CMakeLists.txt
+  sed -i "/set(INSTALL_VERSION \"\${PROJECT_VERSION}\")/s/^#//g" CMakeLists.txt
   sed -i '/set(INSTALL_VERSION "unreleased")/s/^/#/g' CMakeLists.txt
 
   sed -i "s/availability: unreleased/availability: ${version}/g" h3/sql/install/*.sql


### PR DESCRIPTION
## Summary

- make `scripts/release` fail fast, create the `release-X.Y.Z` branch up front, and validate the requested version against bundled H3 major/minor
- automate release metadata updates across CMake, install SQL availability tags, update SQL filenames/references, regression upgrade targets, `CITATION.cff`, generated API docs, and `CHANGELOG.md`
- make `scripts/postrelease` generate the next empty `--unreleased` update scripts from the released headers, restore `INSTALL_VERSION=unreleased`, restore the upgrade regression target, and validate update references
- update the development release notes so the release and post-release steps point at the automation instead of manual renames

## Validation

- `bash -n scripts/release scripts/postrelease`
- `shellcheck scripts/release scripts/postrelease`
- `scripts/check-metadata`
- `git diff --check`
- `RELEASE_DATE=2026-06-07 scripts/release 4.5.1` in a fresh smoke clone
- `scripts/postrelease` after committing the smoke release output
- duplicate-release smoke: with a committed `4.5.1` changelog fixture, `scripts/release 4.5.1` rejects before creating `release-4.5.1` or changing the worktree
- extra-argument smoke: `scripts/release 4.5.1 2026-06-07` prints usage, exits 2, and does not mutate the worktree
- `codex review --uncommitted` found one postrelease regression-target issue; fixed in this PR
- `codex review --uncommitted`
- `codex review --base origin/main`
- `codex review --commit HEAD`
