### PR TITLE
docs: cover release changes in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,11 @@ avoid adding features or APIs which do not map onto the
 * New Features *
 
 - [#188], Add experimental GiST operator class for `h3index`; initial work in [#42] ([Zacharias Knudsen], [Eric Schoffstall], [Darafei Praliaskouski], [Abel Vázquez Montoro], [@mattiZed])
-- Bump bundled H3 core library to `v4.4.1` and add bindings for new upstream APIs including `h3_grid_ring`, `h3_get_index_digit`, `h3_construct_cell`, and `h3_is_valid_index` ([Darafei Praliaskouski])
-- Bump bundled H3 core library to `v4.5.0`, expose `h3_reverse_directed_edge`, and inherit upstream bidirectional `h3_grid_path_cells` plus stricter cell-to-multipolygon validation ([Darafei Praliaskouski])
+- Add `h3_grid_ring` as the preferred ring traversal API: it returns cells exactly `k` grid steps from the origin and handles pentagon distortion internally ([Darafei Praliaskouski])
+- Add `h3_get_index_digit` and `h3_construct_cell` for inspecting and rebuilding cell indexes from explicit resolution, base-cell, and digit components ([Darafei Praliaskouski])
+- Add `h3_is_valid_index` for validating any H3 index mode, including cells, directed edges, and vertices ([Darafei Praliaskouski])
+- Add `h3_reverse_directed_edge` to reverse a directed edge without manually unpacking its origin and destination cells ([Darafei Praliaskouski])
+- Improve `h3_grid_path_cells` with upstream bidirectional path generation from bundled H3 `v4.5.0` ([Darafei Praliaskouski])
 
 * Breaking Changes *
 
@@ -42,20 +45,32 @@ avoid adding features or APIs which do not map onto the
 
 * Bug Fixes *
 
+- Harden core H3 SQL bindings around null, array, polygon, and error handling; negative traversal distances now report a clear PostgreSQL parameter error ([#192], [Darafei Praliaskouski])
 - Fix distance-result upgrade refresh to follow transitive dependencies through user wrapper functions ([Darafei Praliaskouski])
 - [#165], [#168], Fix PostgreSQL 17+ maintenance-operation failures for `h3_postgis` SQL wrappers by schema-qualifying extension object references ([Darafei Praliaskouski])
 - [#168], Fix pg_dump/restore-style `search_path=''` expression-index replay on `h3_lat_lng_to_cell` ([Darafei Praliaskouski])
 - Fix extension upgrade validation drift for placeholder-qualified SQL, including the PostgreSQL 14 raster class summary helper ([Darafei Praliaskouski])
+- [#181], Fix deprecated alias warnings so each wrapper warns once per backend while preserving parallel-safe behavior ([Darafei Praliaskouski])
 - Fix GiST union summaries to ignore the unused entry-vector slot, keeping internal bounds stable on deeper trees ([Darafei Praliaskouski])
+- Reject invalid cell-to-multipolygon input more strictly with bundled H3 `v4.5.0` ([Darafei Praliaskouski])
 - [#189], Fix SP-GiST picksplit using wrong prefix when batch has mixed parents, silently dropping containment query results ([Eric Schoffstall])
 - [#187], Fix SP-GiST picksplit crash when tree depth exceeds cell resolution ([Eric Schoffstall])
 - [#191], Fix `<@` operator and SP-GiST returning false for self-containment ([Eric Schoffstall])
-- Fix `h3_postgis` geometry output for low-zoom and buffered tile covers, polar seams, and exact whole-world covers, so tile polyfills cover the intended Web Mercator tiles and return valid geometries ([Darafei Praliaskouski])
+- [#194], Fix `h3_postgis` geometry output and polygonization for low-zoom and buffered tile covers, polar seams, exact whole-world covers, disjoint polygon segments, vertex graph sizing, and polygon allocation state ([Paul Ramsey], [Darafei Praliaskouski])
+- Fix Windows builds when PostgreSQL installations do not report include flags through `pg_config --cppflags` ([Darafei Praliaskouski])
 
 * Documentation *
 
+- [#183], Add the packaged h3-pg skill for agent-assisted maintenance workflows ([Darafei Praliaskouski])
+- Update README and package metadata links for the PostGIS repository move ([Regina Obe], [Darafei Praliaskouski])
 - [#157], Document invalid polygon inputs to `h3_polygon_to_cells*` and add guidance for `ST_IsValid()` / `ST_MakeValid()` workflows ([Darafei Praliaskouski])
 - [#165], [#168], Add a maintainer note in migration SQL: avoid function-level `SET search_path` in these wrappers to preserve SQL-function inlining ([Darafei Praliaskouski])
+- Generate and validate GUC documentation from source comments, and teach the SQL documentation parser the operator-class syntax used by the new GiST docs ([Darafei Praliaskouski], [Eric Schoffstall])
+
+* Tooling *
+
+- [#197], Release managers can prepare releases with `scripts/release` and `scripts/postrelease`, including metadata, API-doc, changelog, next-cycle update-file, duplicate-version, and argument checks ([Darafei Praliaskouski])
+- [#184], Contributors and packagers get more reliable validation: build-tree extension-upgrade tests, explicit missing-`pg_validate_extupgrade` reporting, metadata checks, non-Intel PostGIS regression tolerance, and sturdier PGXN, Windows, and macOS CI ([Zacharias Knudsen], [@esiaero], [Darafei Praliaskouski])
 
 </details>
 
@@ -333,20 +348,29 @@ avoid adding features or APIs which do not map onto the
 [#176]: https://github.com/postgis/h3-pg/pull/176
 [#177]: https://github.com/postgis/h3-pg/pull/177
 [#179]: https://github.com/postgis/h3-pg/issues/179
+[#181]: https://github.com/postgis/h3-pg/issues/181
+[#183]: https://github.com/postgis/h3-pg/pull/183
+[#184]: https://github.com/postgis/h3-pg/pull/184
 [#187]: https://github.com/postgis/h3-pg/pull/187
 [#188]: https://github.com/postgis/h3-pg/pull/188
 [#189]: https://github.com/postgis/h3-pg/pull/189
 [#190]: https://github.com/postgis/h3-pg/pull/190
 [#191]: https://github.com/postgis/h3-pg/pull/191
+[#192]: https://github.com/postgis/h3-pg/issues/192
+[#194]: https://github.com/postgis/h3-pg/pull/194
+[#197]: https://github.com/postgis/h3-pg/pull/197
 [Abel Vázquez Montoro]: https://github.com/AbelVM
 [Darafei Praliaskouski]: https://github.com/Komzpa
 [Eric Schoffstall]: https://github.com/yocontra
+[Paul Ramsey]: https://github.com/pramsey
+[Regina Obe]: https://github.com/robe2
 [Zacharias Knudsen]: https://github.com/zachasme
 [@AbelVM]: https://github.com/AbelVM
 [@bayandin]: https://github.com/bayandin
 [@BielStela]: https://github.com/BielStela
 [@devrimgunduz]: https://github.com/devrimgunduz
 [@df7cb]: https://github.com/df7cb
+[@esiaero]: https://github.com/esiaero
 [@jmealo]: https://github.com/jmealo
 [@kalenikaliaksandr]: https://github.com/kalenikaliaksandr
 [@kmacdough]: https://github.com/kmacdough

--- a/docs/h3-pg-skill/SKILL.md
+++ b/docs/h3-pg-skill/SKILL.md
@@ -23,6 +23,11 @@ These exist only in h3-pg, not other H3 language bindings.
 - `a <-> b` — grid distance in cells between two h3index values (`h3`)
 - `geom @ resolution` — index geometry/geography at resolution (`h3_postgis`)
 
+**Inspection and construction helpers** (`h3`):
+- `h3_get_index_digit(cell, resolution)` — inspect the digit at a 1-based resolution step
+- `h3_construct_cell(resolution, base_cell_number, digits[])` — rebuild a cell from explicit components
+- `h3_is_valid_index(index)` — validate any H3 index mode: cell, directed edge, or vertex
+
 **Directed edge convenience** (`h3`):
 - `h3_reverse_directed_edge(edge)` — returns the same directed edge with origin and destination reversed
 
@@ -56,6 +61,8 @@ These exist only in h3-pg, not other H3 language bindings.
 | Grid distance (cells) | `h3_distance(a, b)` | `a <-> b` |
 
 **Antimeridian gotcha:** Cells crossing 180° are split into valid polygons. `ST_Centroid` of a split polygon may fall outside the cell — use `h3::geometry` for centroids instead.
+
+**Ring traversal gotcha:** Prefer `h3_grid_ring(origin, k)` for rings because it handles pentagon distortion internally. Use `h3_grid_ring_unsafe(origin, k)` only when fail-fast behavior or ring-walk ordering matters.
 
 ## Critical v3 → v4 Renames
 


### PR DESCRIPTION
## Summary

- Fill in missing high-level Unreleased changelog coverage for changes merged since `v4.2.3`.
- Keep the PostGIS umbrella item as a project-level reader fact, and move release/build maintenance to the bottom Tooling section.
- Split H3 `v4.4.1`/`v4.5.0` coverage into reader-facing API and behavior bullets instead of version-bump prose.
- Credit contributor work where it maps to concrete entries, including Paul Ramsey on `#194`, Regina Obe on repository-link updates, Zacharias Knudsen on macOS CI, and esiaero on non-Intel PostGIS regression tolerance.
- Move the h3-pg skill into a minimal packaged folder at `docs/h3-pg-skill/SKILL.md` and refresh it with the newly exposed inspection helpers plus safe ring traversal guidance.

## Validation

- `scripts/check-metadata`
- `git diff --check`
- Markdown reference sanity check: no undefined changelog references and no stale `docs/SKILL.md` references
- `python3 /home/kom/.codex/skills/.system/skill-creator/scripts/quick_validate.py docs/h3-pg-skill`
- `codex review --uncommitted`
