### PR TITLE
chore: release 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,8 @@ avoid adding features or APIs which do not map onto the
 
 ## [Unreleased]
 
-<details>
-  <summary>
-    Changes that have landed in master but are not yet released.
-    Click to see more.
-  </summary>
+## [4.5.0] - 2026-06-08
+
 
 * Project *
 
@@ -72,7 +69,6 @@ avoid adding features or APIs which do not map onto the
 - [#197], Release managers can prepare releases with `scripts/release` and `scripts/postrelease`, including metadata, API-doc, changelog, next-cycle update-file, duplicate-version, and argument checks ([Darafei Praliaskouski])
 - [#184], Contributors and packagers get more reliable validation: build-tree extension-upgrade tests, explicit missing-`pg_validate_extupgrade` reporting, metadata checks, non-Intel PostGIS regression tolerance, and sturdier PGXN, Windows, and macOS CI ([Zacharias Knudsen], [@esiaero], [Darafei Praliaskouski])
 
-</details>
 
 ## [4.2.3] - 2025-06-24
 
@@ -270,7 +266,8 @@ avoid adding features or APIs which do not map onto the
 
 - Initial public release
 
-[unreleased]: https://github.com/postgis/h3-pg/compare/v4.2.3...HEAD
+[unreleased]: https://github.com/postgis/h3-pg/compare/v4.5.0...HEAD
+[4.5.0]: https://github.com/postgis/h3-pg/compare/v4.2.3...v4.5.0
 [4.2.3]: https://github.com/postgis/h3-pg/compare/v4.2.2...v4.2.3
 [4.2.2]: https://github.com/postgis/h3-pg/compare/v4.2.1...v4.2.2
 [4.2.1]: https://github.com/postgis/h3-pg/compare/v4.2.0...v4.2.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   given-names: "Zacharias"
   orcid:  https://orcid.org/0000-0003-3662-8396
 title: "h3-pg"
-version: v4.2.3
+version: v4.5.0
 doi: 10.5281/zenodo.6856596
-date-released: 2025-06-24
+date-released: 2026-06-08
 url: "https://github.com/postgis/h3-pg"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,12 @@ endif()
 # Listing the version is nice here since it sets lots of useful variables
 project(
   h3-pg
-  VERSION 4.2.3
+  VERSION 4.5.0
   LANGUAGES C
 )
 # set this to "${PROJECT_VERSION}" on release
-#set(INSTALL_VERSION "${PROJECT_VERSION}")
-set(INSTALL_VERSION "unreleased")
+set(INSTALL_VERSION "${PROJECT_VERSION}")
+#set(INSTALL_VERSION "unreleased")
 set(H3_CORE_VERSION 4.5.0)
 set(H3_CORE_SHA256 0da8a392a6ff77e76b60e6a331a49497d0935b6b7b6899da7a3e2786139b0441)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -67,14 +67,14 @@ Returns the base cell number (0 through 121) associated with the index.
 
 
 ### h3_get_index_digit(`h3index`, resolution `integer`) ⇒ `integer`
-*Since vunreleased*
+*Since v4.5.0*
 
 
 Returns the index digit at a specific resolution step. Resolution numbering is 1-based: pass 1 for the first digit below the base cell, 2 for the next, and so on.
 
 
 ### h3_construct_cell(resolution `integer`, base_cell_number `integer`, digits `integer[]`) ⇒ `h3index`
-*Since vunreleased*
+*Since v4.5.0*
 
 
 Builds a valid H3 cell from explicit components: the target resolution, the base cell number, and a digits array ordered from resolution 1 up to the target resolution. The digits array must contain exactly one non-NULL entry per resolution step.
@@ -88,7 +88,7 @@ Returns true only for valid H3 cell indexes (hexagons or pentagons). Directed ed
 
 
 ### h3_is_valid_index(`h3index`) ⇒ `boolean`
-*Since vunreleased*
+*Since v4.5.0*
 
 
 Returns true for any valid H3 index mode: cell, directed edge, or vertex.
@@ -134,7 +134,7 @@ Preferred disk API with distances. Like h3_grid_disk(), but also returns the gri
 
 
 ### h3_grid_ring(origin `h3index`, [k `integer` = 1]) ⇒ SETOF `h3index`
-*Since vunreleased*
+*Since v4.5.0*
 
 
 Preferred ring API. Returns the cells exactly "k" grid steps from origin. Continues to work near pentagons, but row order is not guaranteed and the result may contain fewer than 6*k cells when pentagonal distortion removes positions from the ring.
@@ -364,7 +364,7 @@ Provides the coordinates defining the unidirectional edge.
 
 
 ### h3_reverse_directed_edge(edge `h3index`) ⇒ `h3index`
-*Since vunreleased*
+*Since v4.5.0*
 
 
 Returns the directed edge with origin and destination cells reversed.

--- a/h3/CMakeLists.txt
+++ b/h3/CMakeLists.txt
@@ -83,7 +83,7 @@ PostgreSQL_add_extension(postgresql_h3
     sql/updates/h3--4.2.0--4.2.1.sql
     sql/updates/h3--4.2.1--4.2.2.sql
     sql/updates/h3--4.2.2--4.2.3.sql
-    sql/updates/h3--4.2.3--unreleased.sql
+    sql/updates/h3--4.2.3--4.5.0.sql
 )
 
 # configure

--- a/h3/sql/install/02-inspection.sql
+++ b/h3/sql/install/02-inspection.sql
@@ -34,14 +34,14 @@ AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
     h3_get_base_cell_number(h3index)
 IS 'Returns the base cell number (0 through 121) associated with the index.';
 
---@ availability: unreleased
+--@ availability: 4.5.0
 CREATE OR REPLACE FUNCTION
     h3_get_index_digit(h3index, resolution integer) RETURNS integer
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
     h3_get_index_digit(h3index, integer)
 IS 'Returns the index digit at a specific resolution step. Resolution numbering is 1-based: pass 1 for the first digit below the base cell, 2 for the next, and so on.';
 
---@ availability: unreleased
+--@ availability: 4.5.0
 CREATE OR REPLACE FUNCTION
     h3_construct_cell(resolution integer, base_cell_number integer, digits integer[]) RETURNS h3index
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
@@ -55,7 +55,7 @@ AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
     h3_is_valid_cell(h3index)
 IS 'Returns true only for valid H3 cell indexes (hexagons or pentagons). Directed edges, vertices, and malformed values return false.';
 
---@ availability: unreleased
+--@ availability: 4.5.0
 CREATE OR REPLACE FUNCTION
     h3_is_valid_index(h3index) RETURNS boolean
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION

--- a/h3/sql/install/03-traversal.sql
+++ b/h3/sql/install/03-traversal.sql
@@ -33,7 +33,7 @@ AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
     h3_grid_disk_distances(h3index, integer)
 IS 'Preferred disk API with distances. Like h3_grid_disk(), but also returns the grid distance from origin for each returned cell. Handles pentagon distortion internally. Row order is not guaranteed.';
 
---@ availability: unreleased
+--@ availability: 4.5.0
 CREATE OR REPLACE FUNCTION
     h3_grid_ring(origin h3index, k integer DEFAULT 1) RETURNS SETOF h3index
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION

--- a/h3/sql/install/06-edge.sql
+++ b/h3/sql/install/06-edge.sql
@@ -75,7 +75,7 @@ AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
     h3_directed_edge_to_boundary(edge h3index)
 IS 'Provides the coordinates defining the unidirectional edge.';
 
---@ availability: unreleased
+--@ availability: 4.5.0
 CREATE OR REPLACE FUNCTION
     h3_reverse_directed_edge(edge h3index) RETURNS h3index
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION

--- a/h3/sql/updates/h3--4.2.3--4.5.0.sql
+++ b/h3/sql/updates/h3--4.2.3--4.5.0.sql
@@ -16,7 +16,7 @@
  */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "ALTER EXTENSION h3 UPDATE TO 'unreleased'" to load this file. \quit
+\echo Use "ALTER EXTENSION h3 UPDATE TO '4.5.0'" to load this file. \quit
 
 -- ---------- ---------- ---------- ---------- ---------- ---------- ----------
 -- Keep the public bigint <-> signature upgrade-safe, refresh stored/indexed

--- a/h3/test/expected/extension.out
+++ b/h3/test/expected/extension.out
@@ -97,7 +97,7 @@ SELECT
     hex,
     h3_distance_user_wrapper(hex) AS dist
 FROM h3_distance_expr_fail_userfn;
-ALTER EXTENSION h3 UPDATE TO 'unreleased';
+ALTER EXTENSION h3 UPDATE TO '4.5.0';
 SELECT (current_setting('server_version_num')::int >= 140000) = EXISTS (
     SELECT 1
     FROM pg_amproc ap

--- a/h3/test/sql/extension.sql
+++ b/h3/test/sql/extension.sql
@@ -114,7 +114,7 @@ SELECT
     h3_distance_user_wrapper(hex) AS dist
 FROM h3_distance_expr_fail_userfn;
 
-ALTER EXTENSION h3 UPDATE TO 'unreleased';
+ALTER EXTENSION h3 UPDATE TO '4.5.0';
 
 SELECT (current_setting('server_version_num')::int >= 140000) = EXISTS (
     SELECT 1

--- a/h3_postgis/CMakeLists.txt
+++ b/h3_postgis/CMakeLists.txt
@@ -41,7 +41,7 @@ PostgreSQL_add_extension(postgresql_h3_postgis
     sql/updates/h3_postgis--4.2.0--4.2.1.sql
     sql/updates/h3_postgis--4.2.1--4.2.2.sql
     sql/updates/h3_postgis--4.2.2--4.2.3.sql
-    sql/updates/h3_postgis--4.2.3--unreleased.sql
+    sql/updates/h3_postgis--4.2.3--4.5.0.sql
 )
 
 # link

--- a/h3_postgis/sql/updates/h3_postgis--4.2.3--4.5.0.sql
+++ b/h3_postgis/sql/updates/h3_postgis--4.2.3--4.5.0.sql
@@ -16,7 +16,7 @@
  */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "ALTER EXTENSION h3_postgis UPDATE TO 'unreleased'" to load this file. \quit
+\echo Use "ALTER EXTENSION h3_postgis UPDATE TO '4.5.0'" to load this file. \quit
 
 -- PostgreSQL 17+ uses a restricted search_path during maintenance operations.
 -- SQL/plpgsql bodies use direct dependency qualification plus explicit
@@ -180,7 +180,7 @@ $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION h3_polygon_to_cells(multi @extschema:postgis@.geometry, resolution integer) RETURNS SETOF h3index
     AS $$ SELECT @extschema:h3@.h3_polygon_to_cells(exterior, holes, resolution) FROM (
-        SELECT 
+        SELECT
             -- extract exterior ring of each polygon
             @extschema:postgis@.ST_MakePolygon(@extschema:postgis@.ST_ExteriorRing(poly))::polygon exterior,
             -- extract holes of each polygon
@@ -261,7 +261,7 @@ $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION h3_polygon_to_cells_experimental(multi @extschema:postgis@.geometry, resolution integer, containment_mode text DEFAULT 'center') RETURNS SETOF h3index
     AS $$ SELECT @extschema:h3@.h3_polygon_to_cells_experimental(exterior, holes, resolution, containment_mode) FROM (
-        SELECT 
+        SELECT
             -- extract exterior ring of each polygon
             @extschema:postgis@.ST_MakePolygon(@extschema:postgis@.ST_ExteriorRing(poly))::polygon exterior,
             -- extract holes of each polygon


### PR DESCRIPTION
## Summary

- Prepare h3-pg `4.5.0` release from current `main`.
- Set project and citation metadata to `v4.5.0` with release date `2026-06-08`.
- Convert `--unreleased` update files, API availability markers, changelog compare links, and extension upgrade regression targets to `4.5.0`.

## Validation

- `scripts/release 4.5.0`
- `scripts/check-metadata`
- `git diff --check`
- release-marker scan: no remaining unreleased SQL/API markers in release paths
- `codex review --uncommitted`
