### PR TITLE
Fix h3_postgis upgrade validation after 4.5.0

### DIFF
--- a/h3_postgis/sql/install/05-regions.sql
+++ b/h3_postgis/sql/install/05-regions.sql
@@ -27,7 +27,7 @@
 --@ refid: h3_polygon_to_cells_geometry
 CREATE OR REPLACE FUNCTION h3_polygon_to_cells(multi geometry, resolution integer) RETURNS SETOF h3index
     AS $$ SELECT @extschema:h3@.h3_polygon_to_cells(exterior, holes, resolution) FROM (
-        SELECT 
+        SELECT
             -- extract exterior ring of each polygon
             @extschema:postgis@.ST_MakePolygon(@extschema:postgis@.ST_ExteriorRing(poly))::polygon exterior,
             -- extract holes of each polygon
@@ -144,7 +144,7 @@ CREATE AGGREGATE h3_cells_to_multi_polygon_geography(h3index) (
 --@ refid: h3_polygon_to_cells_geometry_experimental
 CREATE OR REPLACE FUNCTION h3_polygon_to_cells_experimental(multi geometry, resolution integer, containment_mode text DEFAULT 'center') RETURNS SETOF h3index
     AS $$ SELECT @extschema:h3@.h3_polygon_to_cells_experimental(exterior, holes, resolution, containment_mode) FROM (
-        SELECT 
+        SELECT
             -- extract exterior ring of each polygon
             @extschema:postgis@.ST_MakePolygon(@extschema:postgis@.ST_ExteriorRing(poly))::polygon exterior,
             -- extract holes of each polygon


### PR DESCRIPTION
## Summary
- remove trailing spaces inside two h3_postgis SQL wrapper bodies so fresh install and 4.5.0 -> unreleased upgrade catalog `prosrc` match
- fixes the current `test-linux` failure in `h3_postgis_validate_extupgrade` on `main`

## Validation
- `git diff --check`
- `PATH="$HOME/.cargo/bin:$PATH" cmake -B /tmp/h3pgci-validate -S . -DCMAKE_BUILD_TYPE=Release -DPostgreSQL_CONFIG=$(command -v pg_config)`
- `PATH="$HOME/.cargo/bin:$PATH" cmake --build /tmp/h3pgci-validate -j 32`
- `PATH="$HOME/.cargo/bin:$PATH" ctest --test-dir /tmp/h3pgci-validate --output-on-failure --build-config Release`

Local full CTest result: 6/6 passed on PostgreSQL 18/PostGIS.
