### PR TITLE
feat: use PG_MODULE_MAGIC_EXT in PostgreSQL 18 and later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@ avoid adding features or APIs which do not map onto the
 
 ## [Unreleased]
 
-## [4.5.0] - 2026-06-08
+- Use `PG_MODULE_MAGIC_EXT` macro in PostgreSQL 18 and later ([#203], [Andreas Karlsson])
 
-- Use `PG_MODULE_MAGIC_EXT` macro in PostgreSQL 18 and later ([Andreas Karlsson])
+## [4.5.0] - 2026-06-08
 
 ### Project
 
@@ -357,7 +357,9 @@ avoid adding features or APIs which do not map onto the
 [#192]: https://github.com/postgis/h3-pg/issues/192
 [#194]: https://github.com/postgis/h3-pg/pull/194
 [#197]: https://github.com/postgis/h3-pg/pull/197
+[#203]: https://github.com/postgis/h3-pg/pull/203
 [Abel Vázquez Montoro]: https://github.com/AbelVM
+[Andreas Karlsson]: https://github.com/jeltz
 [Darafei Praliaskouski]: https://github.com/Komzpa
 [Eric Schoffstall]: https://github.com/yocontra
 [Paul Ramsey]: https://github.com/pramsey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ avoid adding features or APIs which do not map onto the
 
 ## [4.5.0] - 2026-06-08
 
+- Use `PG_MODULE_MAGIC_EXT` macro in PostgreSQL 18 and later ([Andreas Karlsson])
 
 ### Project
 

--- a/h3_postgis/CMakeLists.txt
+++ b/h3_postgis/CMakeLists.txt
@@ -45,6 +45,15 @@ PostgreSQL_add_extension(postgresql_h3_postgis
     sql/updates/h3_postgis--4.5.0--unreleased.sql
 )
 
+# configure
+configure_file(src/config.h.in src/config.h)
+
+# include
+target_include_directories(postgresql_h3_postgis PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR}/src
+  src
+)
+
 # link
 target_link_libraries(postgresql_h3_postgis PRIVATE postgresql_h3_shared h3)
 target_include_directories(postgresql_h3_postgis PRIVATE ${H3_INTERNAL_INCLUDE_DIR})

--- a/h3_postgis/src/config.h.in
+++ b/h3_postgis/src/config.h.in
@@ -14,28 +14,9 @@
  * limitations under the License.
  */
 
-/* required for MSVC */
-#define _USE_MATH_DEFINES
+#ifndef PGH3_CONFIG_H
+#define PGH3_CONFIG_H
 
-#include <postgres.h>
+#define POSTGRESQL_PGH3_VERSION "@INSTALL_VERSION@"
 
-#include <fmgr.h> // PG_MODULE_MAGIC
-
-#include "config.h"
-#include "guc.h"
-
-/* see https://www.postgresql.org/docs/current/xfunc-c.html#XFUNC-C-DYNLOAD */
-#if POSTGRESQL_VERSION_MAJOR >= 18
-PG_MODULE_MAGIC_EXT(.name = "h3", .version = POSTGRESQL_H3_VERSION);
-#else
-PG_MODULE_MAGIC;
-#endif
-
-void
-_PG_init(void)
-{
-	/* In case we allow using shared library h3, */
-	/* we could make version number assertion here */
-
-	_guc_init();
-}
+#endif /* PGH3_CONFIG_H */

--- a/h3_postgis/src/config.h.in
+++ b/h3_postgis/src/config.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Zacharias Knudsen
+ * Copyright 2026 Andreas Karlsson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/h3_postgis/src/init.c
+++ b/h3_postgis/src/init.c
@@ -18,5 +18,11 @@
 
 #include <fmgr.h> // PG_MODULE_MAGIC
 
+#include "config.h"
+
 /* see https://www.postgresql.org/docs/current/xfunc-c.html#XFUNC-C-DYNLOAD */
+#if POSTGRESQL_VERSION_MAJOR >= 18
+PG_MODULE_MAGIC_EXT(.name = "h3_postgis", .version = POSTGRESQL_PGH3_VERSION);
+#else
 PG_MODULE_MAGIC;
+#endif


### PR DESCRIPTION
The `PG_MODULE_MAGIC_EXT` macro was added in PostgreSQL 18 and makes it possible to see which version of the library is actually loaded using `pg_get_loaded_modules()`.

I updated the change log myself, just tell me if that is against the project practice.